### PR TITLE
chore: setup repository conventions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewer for IMDFlex pull requests.
+* @luminouxx

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,8 +1,8 @@
 ---
 name: Bug Report
 about: Report a bug
-title: '[Bug] '
-labels: bug
+title: 'fix: '
+labels: bug, fix
 assignees: ''
 ---
 
@@ -13,9 +13,13 @@ assignees: ''
 <!-- What should have happened? -->
 
 ## Steps to Reproduce
-1. 
-2. 
-3. 
+1. TODO
+2. TODO
+3. TODO
+
+## Acceptance Criteria
+- [ ] TODO
+- [ ] TODO
 
 ## Environment
 - iOS Version:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,8 +1,8 @@
 ---
 name: Feature Request
 about: Suggest a new feature
-title: '[Feature] '
-labels: enhancement
+title: 'feat: '
+labels: feat
 assignees: ''
 ---
 
@@ -14,6 +14,14 @@ assignees: ''
 
 ## Proposed Solution
 <!-- How should it work? -->
+
+## Acceptance Criteria
+- [ ] TODO
+- [ ] TODO
+- [ ] TODO
+
+## IMDF Impact
+<!-- Schema, GeoJSON, category, relationship, export, or validator impact. Write "None" if not applicable. -->
 
 ## Alternatives Considered
 <!-- Other approaches you've thought about -->

--- a/.github/ISSUE_TEMPLATE/hotfix.md
+++ b/.github/ISSUE_TEMPLATE/hotfix.md
@@ -1,0 +1,26 @@
+---
+name: Hotfix
+about: Urgent production or release-blocking fix
+title: 'fix: '
+labels: hotfix, fix
+assignees: ''
+---
+
+## Summary
+<!-- What must be fixed immediately? -->
+
+## Impact
+<!-- Who or what is affected? -->
+
+## Proposed Fix
+<!-- Short plan for the hotfix. -->
+
+## Acceptance Criteria
+- [ ] TODO
+- [ ] TODO
+
+## Verification
+<!-- Required checks before merging. -->
+
+## Related Context
+<!-- Links, logs, screenshots, or related issues. -->

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,8 +1,8 @@
 ---
 name: Task
 about: Development task
-title: '[Task] '
-labels: task
+title: 'chore: '
+labels: chore
 assignees: ''
 ---
 
@@ -10,8 +10,8 @@ assignees: ''
 <!-- What needs to be done? -->
 
 ## Tasks
-- [ ] Task 1
-- [ ] Task 2
+- [ ] TODO
+- [ ] TODO
 
 ## Acceptance Criteria
 <!-- How do we know it's done? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,26 +1,62 @@
 ## Summary
-<!-- Brief description of changes -->
 
-## Changes
-<!-- List key changes -->
-- 
-- 
+<!-- Briefly explain what changed and why. -->
 
 ## Type
-- [ ] Feature
-- [ ] Bug Fix
-- [ ] Refactor
-- [ ] Documentation
-- [ ] Chore
 
-## Testing
-- [ ] Unit tests added/updated
-- [ ] UI tested on simulator
-- [ ] `tuist generate` succeeds
-- [ ] Build succeeds
+<!-- PR title should use the same prefix, e.g. `feat: add IMDF manifest export`. -->
 
-## Screenshots
-<!-- If UI changes -->
+- [ ] `feat:` user-facing feature
+- [ ] `fix:` bug fix
+- [ ] `fix:` hotfix
+- [ ] `refactor:` internal restructuring
+- [ ] `chore:` maintenance/tooling
+- [ ] `docs:` documentation
+- [ ] `test:` tests only
+
+## Changes
+
+- TODO
+- TODO
+- TODO
+
+## IMDF Impact
+
+<!-- Note schema, GeoJSON, category, relationship, export, or validator impact. Write "None" if not applicable. -->
+
+- TODO
+
+## Architecture Notes
+
+<!-- Note module boundaries, protocols/interfaces touched, and dependency direction. Write "None" if not applicable. -->
+
+- TODO
+
+## Verification
+
+<!-- Report module-by-module results. If not run, explain why. -->
+
+- [ ] `Domain`:
+- [ ] `Data`:
+- [ ] `Presentation`:
+- [ ] `DesignSystem`:
+- [ ] `App`:
+- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`:
+- [ ] Apple IMDF Validator / preflight:
+
+## Screenshots Or Recording
+
+<!-- Required for UI changes. Delete this note if not applicable. -->
 
 ## Related Issues
-<!-- Closes #issue_number -->
+
+<!-- Use `Closes #issue_number` or `Refs #issue_number`. -->
+
+## Checklist
+
+- [ ] Issue exists before implementation work.
+- [ ] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
+- [ ] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
+- [ ] Changes access other modules through public interfaces/protocols.
+- [ ] IMDF schema assumptions are documented or linked.
+- [ ] User-facing behavior has been tested or explained.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,182 @@
+# AGENTS.md
+
+This file defines how coding agents should work in the IMDFlex repository.
+
+## Role
+
+Act as a senior iOS/macOS engineer for IMDFlex. You are responsible for code implementation, product and technical design, verification, and migration records.
+
+IMDFlex is an Apple IMDF authoring app for iPad and Mac. It should help users create indoor map data from Apple Maps context, floor-plan image overlays, point-based drawing tools, and an Apple-submission-oriented IMDF ZIP export flow.
+
+## Product Direction
+
+- IMDFlex is the product repository.
+- `luminouxx/IMDF-Generator` is a reference and migration source, not a repository to copy over wholesale.
+- Preserve the project-based workflow:
+  1. Create or open a project.
+  2. Search an address on Apple Maps.
+  3. Lock map position, zoom, and orientation.
+  4. Create levels.
+  5. Add and align floor-plan overlays per level.
+  6. Edit IMDF features by feature type using point-based drawing tools.
+  7. Export `imdf.zip`.
+  8. Run preflight checks and guide Apple IMDF Validator verification.
+- Floor-plan overlays should support moving, scaling, rotating, opacity adjustment, and alignment against the building outline.
+- The MVP IMDF feature scope is:
+  - `address`
+  - `venue`
+  - `building`
+  - `footprint`
+  - `level`
+  - `unit`
+  - `opening`
+  - `amenity`
+  - `occupant`
+
+## Technology
+
+- Target iOS 18+ and Mac support where the product design requires it.
+- Use Swift 6+ and modern Swift concurrency.
+- Use SwiftUI and MapKit.
+- Use Tuist for project generation.
+- Follow the existing Clean Architecture module structure:
+  - `App`
+  - `Presentation`
+  - `Domain`
+  - `Data`
+  - `DesignSystem`
+- Do not introduce third-party dependencies without explicit approval.
+- Avoid UIKit unless it is required for platform integration or there is no clean SwiftUI/MapKit alternative.
+
+## Architecture
+
+- Keep modules separated by responsibility.
+- Access other modules through public interfaces and protocols. Do not reach across module boundaries into concrete implementation details.
+- `Presentation` may depend on `Domain` and `DesignSystem`.
+- `Data` may depend on `Domain`.
+- `Domain` must remain independent of UI and persistence implementation details.
+- Prefer protocol-based dependency injection for repositories, exporters, validators, and services.
+- Keep business logic testable outside SwiftUI views.
+- Place view logic in testable model/coordinator/service types rather than burying it in view bodies.
+- Do not turn the product into only a feature-by-feature CRUD app. Keep the map-first IMDF authoring workflow central.
+
+## Swift
+
+- Prefer `async/await` over closure-based APIs when modern APIs exist.
+- Assume strict Swift concurrency.
+- Prefer `@Observable` classes over `ObservableObject`, `@Published`, `@StateObject`, `@ObservedObject`, and `@EnvironmentObject`.
+- Mark `@Observable` classes as `@MainActor` unless project-wide main actor isolation is explicitly configured.
+- Use `@State` for owned observable models, and `@Bindable` / `@Environment` for passing shared observable state.
+- Avoid force unwraps and force `try` unless the failure is truly unrecoverable.
+- Prefer modern Foundation APIs such as `URL.documentsDirectory`, `appending(path:)`, `Date.formatted(...)`, and `FormatStyle`.
+- Avoid legacy `Formatter` subclasses when modern format styles work.
+- Avoid old-style GCD such as `DispatchQueue.main.async`; use Swift concurrency.
+- Filter user-facing text with `localizedStandardContains()` rather than plain `contains()`.
+- Prefer Swift-native APIs where practical.
+
+## SwiftUI
+
+- Follow Apple's Human Interface Guidelines and App Review guidelines.
+- Use `foregroundStyle()` rather than `foregroundColor()`.
+- Use `clipShape(.rect(cornerRadius:))` rather than `cornerRadius()`.
+- Use `NavigationStack`, not `NavigationView`.
+- Use `navigationDestination(for:)` for navigation.
+- Use the modern `Tab` API rather than `tabItem()` when available for the target.
+- Do not use the one-parameter `onChange()` variant.
+- Prefer `Button` over `onTapGesture()` unless tap location or tap count is needed.
+- Do not use `Task.sleep(nanoseconds:)`; use `Task.sleep(for:)`.
+- Do not use `UIScreen.main.bounds` for layout.
+- Avoid `AnyView` unless unavoidable.
+- Prefer Dynamic Type and semantic text styles over hard-coded font sizes.
+- Avoid UIKit colors in SwiftUI code.
+- Break complex views into small `View` structs rather than large computed view properties.
+- Use icons in toolbars and controls where appropriate, with accessible labels.
+
+## IMDF And GeoJSON
+
+- Do not claim Apple submission readiness without checking against official Apple IMDF documentation and validator behavior.
+- Treat the Apple IMDF schema and Apple IMDF Validator as the source of truth.
+- GeoJSON positions must be `[longitude, latitude]`, not `[latitude, longitude]`.
+- Preserve feature IDs and relationships carefully.
+- Keep `level_id`, `building_id`, `unit_id`, and related references consistent.
+- Export should produce `imdf.zip` containing the required MVP GeoJSON feature collections.
+- Add or update preflight validation whenever export behavior changes.
+- Surface validator/preflight issues in a way that helps users return to the affected feature.
+
+## Testing And Verification
+
+- Implement features in a testable way.
+- Add focused unit tests for domain logic, serializers, exporters, validators, and geometry behavior.
+- Prefer unit tests over UI tests unless UI tests are the only practical coverage.
+- When changing Tuist configuration, run:
+  - `mise exec -- tuist generate --no-binary-cache --no-open`
+- After code changes, run the most relevant module tests/builds and report results by module.
+- For module-level verification, explicitly report which modules were tested, such as `Domain`, `Data`, `Presentation`, `DesignSystem`, and `App`.
+- If a build/test cannot be run because of local tooling, sandboxing, Xcode simulator issues, or missing dependencies, state that clearly.
+- Use `xcodebuild` with a writable `-derivedDataPath` such as `/private/tmp/imdflex-derived-data` when needed.
+- If SwiftPM or Tuist needs access to user-level caches, request permission rather than working around it unsafely.
+
+## Branches, Commits, And Pull Requests
+
+- Use GitHub Flow:
+  - `main` is the integration branch.
+  - Create short-lived branches from `main`.
+  - Open a PR back into `main`.
+  - Merge only after review and required verification.
+- Do not keep implementation work on `main`.
+- For user-requested implementation work, create or identify a GitHub issue before creating the branch unless the user explicitly asks to skip issue creation.
+- Use GitHub CLI (`gh`) for GitHub issue and PR work when available.
+- Use the `github-flow-steward` skill for repeatable issue, branch, PR, and reviewer workflow.
+- If `gh` is not authenticated, ask the user to run or approve `gh auth login`.
+- If GitHub issue creation is unavailable locally, draft the issue title/body from the matching template and ask the user to create it or provide the issue number.
+- Branches must be connected to the issue number.
+- Branch names should follow:
+  - `feat/<issue-number>-<short-kebab-summary>`
+  - `fix/<issue-number>-<short-kebab-summary>`
+  - `hotfix/<issue-number>-<short-kebab-summary>`
+  - `refactor/<issue-number>-<short-kebab-summary>`
+  - `chore/<issue-number>-<short-kebab-summary>`
+  - `docs/<issue-number>-<short-kebab-summary>`
+  - `test/<issue-number>-<short-kebab-summary>`
+- Use conventional commit/PR title prefixes:
+  - `feat:` for user-facing features
+  - `fix:` for bug fixes
+  - `refactor:` for internal restructuring without behavior changes
+  - `chore:` for maintenance, tooling, generated project updates
+  - `docs:` for documentation-only changes
+  - `test:` for tests-only changes
+- Use `fix:` as the commit/PR prefix for `hotfix/` branches unless the user asks for a different release convention.
+- PR titles should be concise and imperative when possible, e.g. `feat: add IMDF manifest export`.
+- PR descriptions must follow `.github/PULL_REQUEST_TEMPLATE.md`.
+- PR descriptions must link the issue with `Closes #<issue-number>` or `Refs #<issue-number>`.
+- Always include module-by-module verification results in PRs. If a module was not tested, explain why.
+- Keep PRs focused. Split schema, exporter, UI editor, and overlay work when each is substantial.
+- Default code owner/reviewer is configured in `.github/CODEOWNERS`.
+
+## Tuist And Xcode Project Files
+
+- Prefer editing Tuist manifests and source files over hand-editing generated `.xcodeproj` files.
+- Do not make broad manual changes to generated Xcode project files.
+- Regenerate project files after Tuist manifest changes.
+- If generated workspace or project files behave unexpectedly, investigate the Tuist manifest first.
+
+## Migration Records
+
+- Record meaningful migration decisions in `docs/`.
+- Keep `docs/IMDF-Generator-migration.md` updated when moving concepts from IMDF-Generator into IMDFlex.
+- Do not overwrite IMDFlex with IMDF-Generator. Port concepts deliberately into the existing module structure.
+
+## Safety
+
+- Do not revert user changes unless explicitly asked.
+- Keep edits scoped to the task.
+- Do not add secrets, API keys, credentials, provisioning profiles, or personal machine state to the repository.
+- Do not make destructive git or filesystem changes without explicit approval.
+- Do not add generated or cache artifacts unless they are intentionally tracked by the project.
+
+## Communication
+
+- Explain important architectural choices briefly.
+- Report test and build outcomes clearly, especially module-by-module Tuist results.
+- Note assumptions when IMDF schema behavior has not yet been verified against Apple sources.
+- Prefer English for agent instructions in this file. Product notes in `docs/` may use Korean or English depending on context.

--- a/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
+++ b/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
@@ -1,33 +1,379 @@
 import Foundation
 import Domain
 
-/// IMDF GeoJSON 내보내기
+/// Builds an IMDF archive from the app's project model.
 public final class IMDFExporter: IMDFExporterProtocol, Sendable {
-    
     public init() {}
-    
+
     public func export(_ venue: Venue) async throws -> Data {
-        // IMDF Archive는 여러 GeoJSON 파일의 ZIP
-        // 간단히 venue.geojson만 우선 구현
-        let geoJSON = try buildVenueGeoJSON(venue)
-        return try JSONSerialization.data(withJSONObject: geoJSON, options: .prettyPrinted)
+        let files = try IMDFArchiveBuilder(venue: venue).makeFiles()
+        return try ZipArchiveWriter(files: files).makeArchive()
     }
-    
-    private func buildVenueGeoJSON(_ venue: Venue) throws -> [String: Any] {
+}
+
+private struct IMDFArchiveBuilder {
+    let venue: Venue
+
+    func makeFiles() throws -> [String: Data] {
+        var files: [String: Data] = [:]
+
+        files["address.geojson"] = try encode(collection(addressFeatures()))
+        files["venue.geojson"] = try encode(collection([venueFeature()]))
+        files["building.geojson"] = try encode(collection(buildingFeatures()))
+        files["footprint.geojson"] = try encode(collection(footprintFeatures()))
+        files["level.geojson"] = try encode(collection(levelFeatures()))
+        files["unit.geojson"] = try encode(collection(unitFeatures()))
+        files["opening.geojson"] = try encode(collection(openingFeatures()))
+        files["amenity.geojson"] = try encode(collection(amenityFeatures()))
+        files["occupant.geojson"] = try encode(collection(occupantFeatures()))
+
+        return files
+    }
+
+    private func collection(_ features: [[String: Any]]) -> [String: Any] {
         [
             "type": "FeatureCollection",
-            "features": [
-                [
-                    "type": "Feature",
-                    "id": venue.id.uuidString,
-                    "feature_type": "venue",
-                    "properties": [
-                        "name": venue.name,
-                        "category": venue.category.rawValue
-                    ],
-                    "geometry": NSNull()
-                ]
-            ]
+            "features": features
         ]
+    }
+
+    private func encode(_ object: [String: Any]) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private func addressFeatures() -> [[String: Any]] {
+        guard let address = venue.address else { return [] }
+
+        return [
+            feature(
+                id: address.id,
+                featureType: "address",
+                geometry: NSNull(),
+                properties: compact([
+                    "address": address.address,
+                    "locality": address.locality,
+                    "province": address.province,
+                    "country": address.country,
+                    "postal_code": address.postalCode
+                ])
+            )
+        ]
+    }
+
+    private func venueFeature() -> [String: Any] {
+        feature(
+            id: venue.id,
+            featureType: "venue",
+            geometry: NSNull(),
+            properties: compact([
+                "name": localized(venue.name),
+                "category": venue.category.rawValue,
+                "address_id": venue.address?.id.uuidString
+            ])
+        )
+    }
+
+    private func buildingFeatures() -> [[String: Any]] {
+        venue.buildings.map { building in
+            feature(
+                id: building.id,
+                featureType: "building",
+                geometry: NSNull(),
+                properties: compact([
+                    "name": localized(building.name),
+                    "venue_id": venue.id.uuidString
+                ])
+            )
+        }
+    }
+
+    private func footprintFeatures() -> [[String: Any]] {
+        venue.buildings.compactMap { building in
+            guard let footprint = building.footprint else { return nil }
+
+            return feature(
+                id: footprint.id,
+                featureType: "footprint",
+                geometry: polygonGeometry(footprint.coordinates),
+                properties: compact([
+                    "building_id": building.id.uuidString
+                ])
+            )
+        }
+    }
+
+    private func levelFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.map { level in
+                feature(
+                    id: level.id,
+                    featureType: "level",
+                    geometry: NSNull(),
+                    properties: compact([
+                        "name": localized(level.name),
+                        "short_name": localized(level.shortName),
+                        "ordinal": level.ordinal,
+                        "building_id": building.id.uuidString
+                    ])
+                )
+            }
+        }
+    }
+
+    private func unitFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.units.map { unit in
+                    feature(
+                        id: unit.id,
+                        featureType: "unit",
+                        geometry: polygonGeometry(unit.coordinates),
+                        properties: compact([
+                            "category": unit.category.rawValue,
+                            "name": localized(unit.name),
+                            "level_id": level.id.uuidString,
+                            "building_id": building.id.uuidString,
+                            "display_point": displayPoint(for: unit.coordinates)
+                        ])
+                    )
+                }
+            }
+        }
+    }
+
+    private func openingFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.openings.map { opening in
+                    feature(
+                        id: opening.id,
+                        featureType: "opening",
+                        geometry: lineGeometry(opening.coordinates),
+                        properties: compact([
+                            "category": opening.category.rawValue,
+                            "access_control": opening.accessControl?.rawValue,
+                            "level_id": level.id.uuidString,
+                            "building_id": building.id.uuidString
+                        ])
+                    )
+                }
+            }
+        }
+    }
+
+    private func amenityFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.units.flatMap { unit in
+                    unit.amenities.map { amenity in
+                        feature(
+                            id: amenity.id,
+                            featureType: "amenity",
+                            geometry: pointGeometry(amenity.coordinate),
+                            properties: compact([
+                                "category": amenity.category.rawValue,
+                                "name": localized(amenity.name),
+                                "unit_id": unit.id.uuidString,
+                                "level_id": level.id.uuidString,
+                                "building_id": building.id.uuidString
+                            ])
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func occupantFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.units.flatMap { unit in
+                    unit.occupants.map { occupant in
+                        feature(
+                            id: occupant.id,
+                            featureType: "occupant",
+                            geometry: NSNull(),
+                            properties: compact([
+                                "name": localized(occupant.name),
+                                "category": occupant.category?.rawValue,
+                                "phone": occupant.phone,
+                                "website": occupant.website?.absoluteString,
+                                "hours": occupant.hours,
+                                "unit_id": unit.id.uuidString,
+                                "level_id": level.id.uuidString,
+                                "building_id": building.id.uuidString
+                            ])
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private func feature(
+        id: UUID,
+        featureType: String,
+        geometry: Any,
+        properties: [String: Any]
+    ) -> [String: Any] {
+        [
+            "id": id.uuidString,
+            "type": "Feature",
+            "feature_type": featureType,
+            "geometry": geometry,
+            "properties": properties
+        ]
+    }
+
+    private func polygonGeometry(_ coordinates: [Coordinate]) -> [String: Any] {
+        [
+            "type": "Polygon",
+            "coordinates": [closedRing(coordinates).map(position)]
+        ]
+    }
+
+    private func lineGeometry(_ coordinates: [Coordinate]) -> [String: Any] {
+        [
+            "type": "LineString",
+            "coordinates": coordinates.map(position)
+        ]
+    }
+
+    private func pointGeometry(_ coordinate: Coordinate?) -> Any {
+        guard let coordinate else { return NSNull() }
+        return [
+            "type": "Point",
+            "coordinates": position(coordinate)
+        ]
+    }
+
+    private func displayPoint(for coordinates: [Coordinate]) -> [String: Any]? {
+        guard !coordinates.isEmpty else { return nil }
+        let latitude = coordinates.map(\.latitude).reduce(0, +) / Double(coordinates.count)
+        let longitude = coordinates.map(\.longitude).reduce(0, +) / Double(coordinates.count)
+
+        return [
+            "type": "Point",
+            "coordinates": [longitude, latitude]
+        ]
+    }
+
+    private func closedRing(_ coordinates: [Coordinate]) -> [Coordinate] {
+        guard let first = coordinates.first, let last = coordinates.last else { return coordinates }
+        guard first != last else { return coordinates }
+        return coordinates + [first]
+    }
+
+    private func position(_ coordinate: Coordinate) -> [Double] {
+        [coordinate.longitude, coordinate.latitude]
+    }
+
+    private func localized(_ value: String?) -> [String: String]? {
+        guard let value, !value.isEmpty else { return nil }
+        return ["ko": value]
+    }
+
+    private func compact(_ values: [String: Any?]) -> [String: Any] {
+        values.reduce(into: [:]) { result, pair in
+            if let value = pair.value {
+                result[pair.key] = value
+            }
+        }
+    }
+}
+
+private struct ZipArchiveWriter {
+    let files: [String: Data]
+
+    func makeArchive() throws -> Data {
+        var archive = Data()
+        var centralDirectory = Data()
+
+        for (name, data) in files.sorted(by: { $0.key < $1.key }) {
+            let offset = UInt32(archive.count)
+            let nameData = Data(name.utf8)
+            let checksum = CRC32.checksum(data)
+
+            archive.appendUInt32LE(0x04034b50)
+            archive.appendUInt16LE(20)
+            archive.appendUInt16LE(0)
+            archive.appendUInt16LE(0)
+            archive.appendUInt16LE(0)
+            archive.appendUInt16LE(0)
+            archive.appendUInt32LE(checksum)
+            archive.appendUInt32LE(UInt32(data.count))
+            archive.appendUInt32LE(UInt32(data.count))
+            archive.appendUInt16LE(UInt16(nameData.count))
+            archive.appendUInt16LE(0)
+            archive.append(nameData)
+            archive.append(data)
+
+            centralDirectory.appendUInt32LE(0x02014b50)
+            centralDirectory.appendUInt16LE(20)
+            centralDirectory.appendUInt16LE(20)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt32LE(checksum)
+            centralDirectory.appendUInt32LE(UInt32(data.count))
+            centralDirectory.appendUInt32LE(UInt32(data.count))
+            centralDirectory.appendUInt16LE(UInt16(nameData.count))
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt16LE(0)
+            centralDirectory.appendUInt32LE(0)
+            centralDirectory.appendUInt32LE(offset)
+            centralDirectory.append(nameData)
+        }
+
+        let centralDirectoryOffset = UInt32(archive.count)
+        archive.append(centralDirectory)
+
+        archive.appendUInt32LE(0x06054b50)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(0)
+        archive.appendUInt16LE(UInt16(files.count))
+        archive.appendUInt16LE(UInt16(files.count))
+        archive.appendUInt32LE(UInt32(centralDirectory.count))
+        archive.appendUInt32LE(centralDirectoryOffset)
+        archive.appendUInt16LE(0)
+
+        return archive
+    }
+}
+
+private enum CRC32 {
+    static func checksum(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xffff_ffff
+
+        for byte in data {
+            crc ^= UInt32(byte)
+
+            for _ in 0..<8 {
+                if crc & 1 == 1 {
+                    crc = (crc >> 1) ^ 0xedb8_8320
+                } else {
+                    crc >>= 1
+                }
+            }
+        }
+
+        return crc ^ 0xffff_ffff
+    }
+}
+
+private extension Data {
+    mutating func appendUInt16LE(_ value: UInt16) {
+        append(UInt8(value & 0x00ff))
+        append(UInt8((value >> 8) & 0x00ff))
+    }
+
+    mutating func appendUInt32LE(_ value: UInt32) {
+        append(UInt8(value & 0x0000_00ff))
+        append(UInt8((value >> 8) & 0x0000_00ff))
+        append(UInt8((value >> 16) & 0x0000_00ff))
+        append(UInt8((value >> 24) & 0x0000_00ff))
     }
 }

--- a/IMDFlex/Tuist/ProjectDescriptionHelpers/Constants/Project+Dependencies.swift
+++ b/IMDFlex/Tuist/ProjectDescriptionHelpers/Constants/Project+Dependencies.swift
@@ -10,7 +10,7 @@ public enum Module: String, CaseIterable {
     
     /// Return Absolute Path (for Workspace.swift)
     public var absolutePath: Path {
-        "Project/\(name)"
+        "Projects/\(name)"
     }
     
     /// Return Relative Path

--- a/docs/IMDF-Generator-migration.md
+++ b/docs/IMDF-Generator-migration.md
@@ -1,0 +1,53 @@
+# IMDF-Generator Migration Notes
+
+IMDFlex continues the product direction from `luminouxx/IMDF-Generator`, but keeps the Tuist-based modular structure already present in this repository.
+
+## Migration Direction
+
+- Keep IMDFlex as the product repository.
+- Move concepts from IMDF-Generator into the existing modules:
+  - `Domain`: IMDF entities and feature relationships.
+  - `Data`: project persistence, GeoJSON serialization, IMDF ZIP export.
+  - `Presentation`: project workflow, MapKit editor, image overlay alignment.
+- Re-check all IMDF entities against Apple IMDF requirements before treating exported archives as submission-ready.
+
+## MVP Feature Scope
+
+The MVP targets these IMDF feature collections:
+
+- `address.geojson`
+- `venue.geojson`
+- `building.geojson`
+- `footprint.geojson`
+- `level.geojson`
+- `unit.geojson`
+- `opening.geojson`
+- `amenity.geojson`
+- `occupant.geojson`
+
+## Product Workflow
+
+1. Create or open a project.
+2. Search an address in Apple Maps.
+3. Lock map position, zoom, and orientation.
+4. Create levels.
+5. Add a floor-plan image overlay per level.
+6. Align the overlay by moving, scaling, rotating, and adjusting opacity against the building outline.
+7. Edit IMDF features by feature type using point-based drawing tools.
+8. Export `imdf.zip`.
+9. Run preflight checks and guide Apple IMDF Validator verification.
+
+## Current Migration Status
+
+- Added a ZIP-based `IMDFExporter` foundation that creates the MVP GeoJSON files from the current `Venue` aggregate.
+- Fixed the Tuist workspace project path typo from `Project/` to `Projects/`.
+
+## Next Migration Steps
+
+1. Validate the current Domain entity fields against Apple IMDF schema.
+2. Add a project-level preflight validator for required feature relationships.
+3. Port the IMDF-Generator MapKit point-drawing core into `Presentation/MapEditor`.
+4. Port and redesign the image overlay alignment flow for level-specific floor plans.
+5. Replace the current nested Domain aggregate with explicit feature repositories if editing complexity grows.
+
+See `docs/imdf-schema-gap.md` for the current Apple IMDF validation and category gap analysis.

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -1,0 +1,184 @@
+# IMDF Schema Gap
+
+This document tracks gaps between IMDFlex's current Domain/export model and Apple's official IMDF resources.
+
+## Source Baseline
+
+- Official resource page: `https://register.apple.com/resources/imdf/`
+- IMDF version shown by Apple page: `1.0.0`
+- Last update shown by Apple page: `October 19, 2021`
+- Asset ZIP analyzed: `IMDF.zip`
+- Validation CSV analyzed: `imdf-validations-1.0.3.csv`
+- Category CSV analyzed: `categories_20210728.csv`
+
+## Highest-Risk Gaps
+
+### 1. Manifest Export Is Missing
+
+Apple validation includes:
+
+- `ManifestFileMustBePresent`
+- `ManifestVersionMustBeValid`
+
+Current `IMDFExporter` writes only GeoJSON feature collection files. It does not write `manifest.json`.
+
+Required direction:
+
+- Add a manifest export file.
+- Declare the IMDF version expected by Apple resources.
+- Add tests that exported ZIP archives contain `manifest.json`.
+
+### 2. Venue Geometry Is Wrong For Submission
+
+Apple validation includes:
+
+- `VenueMustHavePolygonalGeometry`
+- `VenueGeometryMustContainDisplayPoint`
+- `VenueMustCoverAllChildFeatures`
+- `VenueMustHaveAddress`
+- `VenueMustHaveAtLeastOneBuilding`
+
+Current exporter emits `venue.geojson` with `geometry: null`.
+
+Required direction:
+
+- Add polygon geometry to the Domain `Venue` model or derive it from footprint/level coverage.
+- Add `display_point`.
+- Keep `address_id` and building coverage relationships valid.
+
+### 3. Level Geometry And Category Are Missing
+
+Apple validation includes:
+
+- `LevelMustHavePolygonalGeometry`
+- `LevelMustHaveCategory`
+- `LevelMustHaveName`
+- `LevelMustHaveShortName`
+- `LevelMustHaveOrdinal`
+- `LevelMustBeReferencedByUnit`
+
+Current `Level` has `name`, `ordinal`, and optional `shortName`, but no geometry or category.
+
+Required direction:
+
+- Add `LevelCategory`.
+- Add level polygon geometry.
+- Make `shortName` required before export or enforce it in preflight.
+- Ensure every exported level is referenced by at least one unit.
+
+### 4. Building And Footprint Categories Are Missing
+
+Apple validation includes:
+
+- `BuildingMustHaveCategory`
+- `BuildingCategoryMustBeValid`
+- `BuildingMustHaveAtLeastOneFootprint`
+- `FootprintCategoryMustBeValid`
+- `FootprintMustHavePolygonalGeometry`
+- `FootprintMustReferenceBuilding`
+
+Current `Building` has no category. Current `Footprint` has no category.
+
+Required direction:
+
+- Add `BuildingCategory` with Apple values.
+- Add `FootprintCategory` with Apple values.
+- Keep footprint-to-building references explicit in exporter and preflight validation.
+
+### 5. Category Raw Values Do Not Match Apple IMDF
+
+Several current enums use app-friendly or snake_case values that are not Apple IMDF raw values.
+
+Examples:
+
+- `VenueCategory.shoppingCenter` currently exports `shopping_center`; Apple category is `shoppingcenter`.
+- `VenueCategory.parkingFacility` currently exports `parking_facility`; Apple category is `parkingfacility`.
+- `UnitCategory.foodService` currently exports `food_service`; Apple category is `foodservice`.
+- `OpeningCategory.emergencyExit` currently exports `emergency_exit`; Apple category is `emergencyexit`.
+- `AccessControl.keyCard` currently exports `key_card`; Apple category list uses values such as `keyaccess`, `badgereader`, and `passwordaccess`.
+
+Required direction:
+
+- Replace or remap enum raw values to Apple CSV values.
+- Consider keeping user-facing labels separate from IMDF raw values.
+- Add tests asserting exported raw values match Apple categories.
+
+### 6. Occupant Requires Anchor
+
+Apple validation includes:
+
+- `OccupantMustReferenceAnchor`
+- `OccupantMustHaveCategory`
+- `OccupantMustHaveName`
+
+Current MVP scope includes `occupant` but not `anchor`. Current `Occupant` has no anchor reference, and current exporter writes `unit_id` instead.
+
+Required direction:
+
+- Decide whether MVP includes `anchor`.
+- If `occupant` remains in MVP, add `Anchor` Domain model and `anchor.geojson` export.
+- If `anchor` is deferred, defer `occupant` from Apple-submission MVP export.
+
+## Feature-Level Gap Table
+
+| Feature | Current Status | Validator-Risk Gap | Priority |
+| --- | --- | --- | --- |
+| Manifest | Not exported | Required manifest missing | P0 |
+| Address | Basic model exists | ISO country/province fields and reference semantics need review | P1 |
+| Venue | Model exists | Missing polygon geometry and display point | P0 |
+| Building | Model exists | Missing category; must have footprint and level references | P0 |
+| Footprint | Model exists | Missing category | P0 |
+| Level | Model exists | Missing polygon geometry and category; short name optional | P0 |
+| Unit | Model exists | Category values need Apple alignment; level containment needs preflight | P1 |
+| Opening | Model exists | Category/access-control values need Apple alignment | P1 |
+| Amenity | Model exists | Coordinate optional but point geometry required; category values incomplete | P1 |
+| Occupant | Model exists | Requires anchor reference; category values incomplete | P0 decision |
+| Anchor | Not in MVP model | Required if exporting occupants | P0 decision |
+
+## Apple Category Baseline For MVP
+
+Use Apple category values as raw export values.
+
+### Venue
+
+`airport`, `airport.intl`, `aquarium`, `businesscampus`, `casino`, `communitycenter`, `conventioncenter`, `governmentfacility`, `healthcarefacility`, `hotel`, `museum`, `parkingfacility`, `resort`, `retailstore`, `shoppingcenter`, `stadium`, `stripmall`, `theater`, `themepark`, `trainstation`, `transitstation`, `university`
+
+### Building
+
+`parking`, `transit`, `transit.bus`, `transit.train`, `unspecified`
+
+### Footprint
+
+`aerial`, `ground`, `subterranean`
+
+### Level
+
+`arrivals`, `arrivals.domestic`, `arrivals.intl`, `departures`, `departures.domestic`, `departures.intl`, `parking`, `transit`, `unspecified`
+
+### Opening
+
+`automobile`, `bicycle`, `emergencyexit`, `pedestrian`, `pedestrian.principal`, `pedestrian.transit`, `service`
+
+### Access Control
+
+`badgereader`, `fingerprintreader`, `guard`, `keyaccess`, `outofservice`, `passwordaccess`, `retinascanner`, `voicerecognition`
+
+## Recommended Implementation Order
+
+1. Add `manifest.json` export and tests.
+2. Add explicit geometry/category fields for `Venue`, `Building`, `Footprint`, and `Level`.
+3. Align MVP category enums with Apple category CSV raw values.
+4. Add a preflight validator for required relationships and required geometry.
+5. Decide `Occupant + Anchor` scope before exporting occupants as Apple-submission data.
+6. Add module tests:
+   - `Domain`: entity construction and category raw values.
+   - `Data`: exported ZIP file list and GeoJSON structure.
+   - `Data`: relationship references and coordinate order.
+   - `Presentation`: later, editor tools should produce valid Domain geometry.
+
+## Open Questions
+
+- Should `Venue` polygon be drawn directly by the user, derived from building footprints, or both?
+- Should `Level` polygon be copied from the building footprint by default?
+- Should `Occupant` be deferred until `Anchor` is implemented?
+- Should full Apple category lists be modeled as enums, or should the app store raw category strings plus curated presets?


### PR DESCRIPTION
## Summary

Set up the repository workflow and first IMDF migration foundation so future work follows issue-first GitHub Flow, conventional naming, module verification, and Apple IMDF schema tracking.

## Type

- [ ] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [x] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added root `AGENTS.md` with IMDFlex engineering, IMDF, test, branch, issue, and PR conventions.
- Updated GitHub issue/PR templates and added `CODEOWNERS` plus a hotfix issue template.
- Added IMDF-Generator migration notes and Apple IMDF schema gap analysis.
- Expanded `IMDFExporter` from a single `venue.geojson` output into a ZIP archive foundation for MVP GeoJSON files.
- Fixed the Tuist workspace path typo from `Project/` to `Projects/`.

## IMDF Impact

- Adds initial ZIP-based export foundation for `address`, `venue`, `building`, `footprint`, `level`, `unit`, `opening`, `amenity`, and `occupant` GeoJSON files.
- Documents current Apple IMDF validation gaps, including missing `manifest.json`, venue/level geometry gaps, category raw-value mismatches, and the `Occupant` -> `Anchor` requirement.
- This PR does not claim Apple IMDF Validator readiness.

## Architecture Notes

- Keeps IMDF-Generator as a migration reference while preserving IMDFlex's Tuist module structure.
- Records module boundary rules: cross-module access should go through public interfaces/protocols.
- Adds PR verification expectations by module.

## Verification

- [x] `Domain`: `mise exec -- tuist build Domain` succeeded.
- [x] `Data`: `mise exec -- tuist build Data` succeeded.
- [x] `Presentation`: covered by `mise exec -- tuist build IMDFlex`, which built `Presentation`.
- [x] `DesignSystem`: covered by `mise exec -- tuist build IMDFlex`, which built `DesignSystem`.
- [x] `App`: `mise exec -- tuist build IMDFlex` succeeded.
- [x] `mise exec -- tuist generate --no-binary-cache --no-open`: succeeded.
- [ ] Apple IMDF Validator / preflight: not run; schema gaps are documented in `docs/imdf-schema-gap.md`.

Additional checks:

- [x] `xcodebuild build -project Projects/Domain/Domain.xcodeproj -scheme Domain -destination generic/platform=iOS -derivedDataPath /private/tmp/imdflex-pr-domain-derived-data` succeeded.
- [x] `git diff --check` succeeded.
- [ ] `mise exec -- tuist test` failed because generated empty test bundles could not be loaded; the failure reported missing test bundle executables for `DataTests`, `DesignSystemTests`, `DomainTests`, `IMDFlexTests`, and `PresentationTests`.

## Screenshots Or Recording

Not applicable.

## Related Issues

Closes #7

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.

## Self-Review Notes

- The exporter still needs `manifest.json`, official category alignment, and venue/level geometry before Apple submission claims.
- `Occupant` export should be revisited because Apple validation requires an `Anchor` reference.
- Test targets should receive real tests or be configured so `tuist test` does not produce unloaded empty bundles.
