### PR TITLE
test: add Domain model validation tests

### DIFF
--- a/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+final class DomainModelTests: XCTestCase {
+    func testVenuePreservesNestedIMDFEntityRelationships() throws {
+        let unit = Unit(
+            id: try uuid("00000000-0000-0000-0000-000000000001"),
+            name: "Lobby",
+            category: .lobby,
+            coordinates: squareCoordinates()
+        )
+        let level = Level(
+            id: try uuid("00000000-0000-0000-0000-000000000002"),
+            name: "Level 1",
+            ordinal: 0,
+            shortName: "1F",
+            units: [unit]
+        )
+        let footprint = Footprint(
+            id: try uuid("00000000-0000-0000-0000-000000000003"),
+            coordinates: squareCoordinates()
+        )
+        let building = Building(
+            id: try uuid("00000000-0000-0000-0000-000000000004"),
+            name: "Main Building",
+            levels: [level],
+            footprint: footprint
+        )
+        let address = Address(
+            id: try uuid("00000000-0000-0000-0000-000000000005"),
+            address: "1 Infinite Loop",
+            locality: "Cupertino",
+            province: "CA",
+            country: "US",
+            postalCode: "95014"
+        )
+        let venue = Venue(
+            id: try uuid("00000000-0000-0000-0000-000000000006"),
+            name: "IMDFlex Test Venue",
+            category: .university,
+            buildings: [building],
+            address: address
+        )
+
+        XCTAssertEqual(venue.buildings.first?.id, building.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.id, level.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.units.first?.id, unit.id)
+        XCTAssertEqual(venue.buildings.first?.footprint?.id, footprint.id)
+        XCTAssertEqual(venue.address?.id, address.id)
+    }
+
+    func testCoordinateEqualityUsesLatitudeAndLongitude() {
+        let coordinate = Coordinate(latitude: 37.33182, longitude: -122.03118)
+
+        XCTAssertEqual(coordinate, Coordinate(latitude: 37.33182, longitude: -122.03118))
+        XCTAssertNotEqual(coordinate, Coordinate(latitude: 37.33182, longitude: -122.03119))
+        XCTAssertNotEqual(coordinate, Coordinate(latitude: 37.33183, longitude: -122.03118))
+    }
+
+    func testFootprintPreservesAuthoredPolygonCoordinates() {
+        let coordinates = squareCoordinates()
+        let footprint = Footprint(coordinates: coordinates)
+
+        XCTAssertEqual(footprint.coordinates, coordinates)
+        XCTAssertEqual(footprint.coordinates.count, 4)
+        XCTAssertNotEqual(footprint.coordinates.first, footprint.coordinates.last)
+    }
+
+    private func uuid(_ string: String) throws -> UUID {
+        try XCTUnwrap(UUID(uuidString: string))
+    }
+
+    private func squareCoordinates() -> [Coordinate] {
+        [
+            Coordinate(latitude: 37.33170, longitude: -122.03110),
+            Coordinate(latitude: 37.33170, longitude: -122.03090),
+            Coordinate(latitude: 37.33190, longitude: -122.03090),
+            Coordinate(latitude: 37.33190, longitude: -122.03110)
+        ]
+    }
+}

--- a/IMDFlex/Projects/Domain/Tests/ProjectUseCaseTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/ProjectUseCaseTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+final class ProjectUseCaseTests: XCTestCase {
+    func testCreateProjectSavesProjectThroughRepositoryProtocol() async throws {
+        let repository = InMemoryProjectRepository()
+        let useCase = ProjectUseCase(repository: repository)
+
+        let project = try await useCase.createProject(name: "Indoor Mapping")
+        let savedProject = try await repository.fetch(id: project.id)
+
+        XCTAssertEqual(savedProject?.id, project.id)
+        XCTAssertEqual(savedProject?.name, "Indoor Mapping")
+        XCTAssertNil(savedProject?.venue)
+    }
+
+    func testLoadProjectsReturnsRepositoryProjects() async throws {
+        let repository = InMemoryProjectRepository()
+        let useCase = ProjectUseCase(repository: repository)
+        let firstProject = IMDFProject(name: "First Project")
+        let secondProject = IMDFProject(name: "Second Project")
+
+        try await repository.save(firstProject)
+        try await repository.save(secondProject)
+
+        let projects = try await useCase.loadProjects()
+        let projectIDs = Set(projects.map(\.id))
+
+        XCTAssertEqual(projectIDs, [firstProject.id, secondProject.id])
+    }
+
+    func testUpdateProjectRefreshesUpdatedAtAndPreservesProjectContent() async throws {
+        let repository = InMemoryProjectRepository()
+        let useCase = ProjectUseCase(repository: repository)
+        let createdAt = Date(timeIntervalSince1970: 100)
+        let oldUpdatedAt = Date(timeIntervalSince1970: 200)
+        let venue = Venue(name: "Venue", category: .university)
+        let project = IMDFProject(
+            name: "Project",
+            venue: venue,
+            createdAt: createdAt,
+            updatedAt: oldUpdatedAt
+        )
+
+        try await useCase.updateProject(project)
+
+        let fetchedProject = try await repository.fetch(id: project.id)
+        let updatedProject = try XCTUnwrap(fetchedProject)
+        XCTAssertEqual(updatedProject.id, project.id)
+        XCTAssertEqual(updatedProject.name, project.name)
+        XCTAssertEqual(updatedProject.venue?.id, venue.id)
+        XCTAssertEqual(updatedProject.createdAt, createdAt)
+        XCTAssertGreaterThan(updatedProject.updatedAt, oldUpdatedAt)
+    }
+
+    func testDeleteProjectRemovesProjectThroughRepositoryProtocol() async throws {
+        let repository = InMemoryProjectRepository()
+        let useCase = ProjectUseCase(repository: repository)
+        let project = IMDFProject(name: "Project To Delete")
+
+        try await repository.save(project)
+        try await useCase.deleteProject(id: project.id)
+
+        let deletedProject = try await repository.fetch(id: project.id)
+        XCTAssertNil(deletedProject)
+    }
+}
+
+private actor InMemoryProjectRepository: ProjectRepositoryProtocol {
+    private var projects: [UUID: IMDFProject] = [:]
+
+    func fetchAll() async throws -> [IMDFProject] {
+        Array(projects.values)
+    }
+
+    func fetch(id: UUID) async throws -> IMDFProject? {
+        projects[id]
+    }
+
+    func save(_ project: IMDFProject) async throws {
+        projects[project.id] = project
+    }
+
+    func delete(id: UUID) async throws {
+        projects[id] = nil
+    }
+}


### PR DESCRIPTION
## Summary

Add the first executable Domain model tests so future IMDF schema/model changes have a stable baseline.

## Type

- [ ] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [x] `test:` tests only

## Changes

- Added Domain model tests for nested `Venue` -> `Building` -> `Level` -> `Unit` relationships.
- Added coordinate and footprint coordinate preservation tests.
- Added `ProjectUseCase` tests using an in-memory repository test double that conforms to the Domain protocol.

## IMDF Impact

- No export behavior changes.
- Establishes test coverage for the current Domain baseline before deeper Apple IMDF schema alignment work.

## Architecture Notes

- Changes are limited to `DomainTests`.
- The in-memory repository is a private test-only `actor` and does not add production dependencies.
- Tests exercise Domain public/protocol-facing behavior only.

## Verification

- [x] `Domain`: `mise exec -- tuist build Domain` succeeded; `mise exec -- tuist test Domain` succeeded with 7 tests.
- [x] `Data`: `mise exec -- tuist build Data` succeeded.
- [ ] `Presentation`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [ ] `DesignSystem`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` succeeded.
- [x] `mise exec -- tuist generate --no-binary-cache --no-open`: succeeded.
- [ ] Apple IMDF Validator / preflight: Not applicable; tests-only change with no export/preflight behavior change.

## Screenshots Or Recording

Not applicable; no UI changes.

## Review Notes

- Check whether these tests describe the Domain contract at the right level, without freezing exporter-specific behavior.
- Check whether the fixture shape is a useful baseline for upcoming schema work around `building`, `footprint`, `level`, and `unit`.
- Check whether `ProjectUseCase.updateProject` behavior should continue to refresh `updatedAt` internally, since this PR now captures that expectation.

## Related Issues

Closes #11

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
