### PR TITLE
feat: align core IMDF feature schema

### DIFF
--- a/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
+++ b/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
@@ -68,14 +68,17 @@ private struct IMDFArchiveBuilder {
     }
 
     private func venueFeature() -> [String: Any] {
-        feature(
+        let coordinates = venueBoundaryCoordinates()
+
+        return feature(
             id: venue.id,
             featureType: "venue",
-            geometry: NSNull(),
+            geometry: polygonGeometry(coordinates),
             properties: compact([
                 "name": localized(venue.name),
                 "category": venue.category.rawValue,
-                "address_id": venue.address?.id.uuidString
+                "address_id": venue.address?.id.uuidString,
+                "display_point": displayPoint(for: coordinates)
             ])
         )
     }
@@ -87,8 +90,10 @@ private struct IMDFArchiveBuilder {
                 featureType: "building",
                 geometry: NSNull(),
                 properties: compact([
+                    "category": building.category.rawValue,
                     "name": localized(building.name),
-                    "venue_id": venue.id.uuidString
+                    "venue_id": venue.id.uuidString,
+                    "display_point": displayPoint(for: building.footprint?.coordinates ?? [])
                 ])
             )
         }
@@ -103,6 +108,7 @@ private struct IMDFArchiveBuilder {
                 featureType: "footprint",
                 geometry: polygonGeometry(footprint.coordinates),
                 properties: compact([
+                    "category": footprint.category.rawValue,
                     "building_id": building.id.uuidString
                 ])
             )
@@ -112,15 +118,19 @@ private struct IMDFArchiveBuilder {
     private func levelFeatures() -> [[String: Any]] {
         venue.buildings.flatMap { building in
             building.levels.map { level in
-                feature(
+                let coordinates = levelBoundaryCoordinates(for: level, building: building)
+
+                return feature(
                     id: level.id,
                     featureType: "level",
-                    geometry: NSNull(),
+                    geometry: polygonGeometry(coordinates),
                     properties: compact([
+                        "category": level.category.rawValue,
                         "name": localized(level.name),
                         "short_name": localized(level.shortName),
                         "ordinal": level.ordinal,
-                        "building_id": building.id.uuidString
+                        "building_id": building.id.uuidString,
+                        "display_point": displayPoint(for: coordinates)
                     ])
                 )
             }
@@ -262,6 +272,46 @@ private struct IMDFArchiveBuilder {
         return [
             "type": "Point",
             "coordinates": [longitude, latitude]
+        ]
+    }
+
+    private func venueBoundaryCoordinates() -> [Coordinate] {
+        if !venue.coordinates.isEmpty {
+            return venue.coordinates
+        }
+
+        let footprintCoordinates = venue.buildings.compactMap(\.footprint).flatMap(\.coordinates)
+        return enclosingRing(for: footprintCoordinates)
+    }
+
+    private func levelBoundaryCoordinates(for level: Level, building: Building) -> [Coordinate] {
+        if !level.coordinates.isEmpty {
+            return level.coordinates
+        }
+
+        return building.footprint?.coordinates ?? []
+    }
+
+    private func enclosingRing(for coordinates: [Coordinate]) -> [Coordinate] {
+        guard let first = coordinates.first else { return [] }
+
+        var minLatitude = first.latitude
+        var maxLatitude = first.latitude
+        var minLongitude = first.longitude
+        var maxLongitude = first.longitude
+
+        for coordinate in coordinates.dropFirst() {
+            minLatitude = min(minLatitude, coordinate.latitude)
+            maxLatitude = max(maxLatitude, coordinate.latitude)
+            minLongitude = min(minLongitude, coordinate.longitude)
+            maxLongitude = max(maxLongitude, coordinate.longitude)
+        }
+
+        return [
+            Coordinate(latitude: minLatitude, longitude: minLongitude),
+            Coordinate(latitude: minLatitude, longitude: maxLongitude),
+            Coordinate(latitude: maxLatitude, longitude: maxLongitude),
+            Coordinate(latitude: maxLatitude, longitude: minLongitude)
         ]
     }
 

--- a/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
+++ b/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
@@ -38,8 +38,7 @@ final class IMDFExporterTests: XCTestCase {
         let venue = sampleVenue()
         let archive = try await IMDFExporter().export(venue)
         let entries = try ZipArchiveReader.entries(from: archive)
-        let venueData = try XCTUnwrap(entries["venue.geojson"])
-        let venueCollection = try XCTUnwrap(JSONSerialization.jsonObject(with: venueData) as? [String: Any])
+        let venueCollection = try featureCollection(named: "venue.geojson", from: entries)
         let features = try XCTUnwrap(venueCollection["features"] as? [[String: Any]])
         let feature = try XCTUnwrap(features.first)
 
@@ -49,27 +48,99 @@ final class IMDFExporterTests: XCTestCase {
         XCTAssertEqual(feature["feature_type"] as? String, "venue")
     }
 
+    func testExportWritesCoreFeatureSchemaProperties() async throws {
+        let venue = sampleVenue()
+        let archive = try await IMDFExporter().export(venue)
+        let entries = try ZipArchiveReader.entries(from: archive)
+        let building = try XCTUnwrap(venue.buildings.first)
+        let level = try XCTUnwrap(building.levels.first)
+
+        let venueProperties = try properties(in: "venue.geojson", from: entries)
+        let buildingProperties = try properties(in: "building.geojson", from: entries)
+        let footprintProperties = try properties(in: "footprint.geojson", from: entries)
+        let levelProperties = try properties(in: "level.geojson", from: entries)
+
+        XCTAssertEqual(venueProperties["category"] as? String, "shoppingcenter")
+        XCTAssertEqual(venueProperties["address_id"] as? String, venue.address?.id.uuidString)
+        XCTAssertEqual(buildingProperties["category"] as? String, "unspecified")
+        XCTAssertEqual(buildingProperties["venue_id"] as? String, venue.id.uuidString)
+        XCTAssertEqual(footprintProperties["category"] as? String, "ground")
+        XCTAssertEqual(footprintProperties["building_id"] as? String, building.id.uuidString)
+        XCTAssertEqual(levelProperties["category"] as? String, "unspecified")
+        XCTAssertEqual(levelProperties["building_id"] as? String, building.id.uuidString)
+        XCTAssertEqual(levelProperties["ordinal"] as? Int, level.ordinal)
+    }
+
+    func testExportWritesCorePolygonGeometryAndDisplayPoints() async throws {
+        let archive = try await IMDFExporter().export(sampleVenue())
+        let entries = try ZipArchiveReader.entries(from: archive)
+
+        let venueFeature = try singleFeature(in: "venue.geojson", from: entries)
+        let venueGeometry = try geometry(from: venueFeature)
+        let venueCoordinates = try polygonCoordinates(from: venueGeometry)
+        let venueProperties = try XCTUnwrap(venueFeature["properties"] as? [String: Any])
+        let venueDisplayPoint = try XCTUnwrap(venueProperties["display_point"] as? [String: Any])
+
+        XCTAssertEqual(venueGeometry["type"] as? String, "Polygon")
+        XCTAssertEqual(venueCoordinates.first?.first, [-122.03130, 37.33150])
+        XCTAssertEqual(venueCoordinates.first?.last, [-122.03130, 37.33150])
+        XCTAssertEqual(venueDisplayPoint["type"] as? String, "Point")
+
+        let footprintGeometry = try geometry(in: "footprint.geojson", from: entries)
+        let footprintCoordinates = try polygonCoordinates(from: footprintGeometry)
+        XCTAssertEqual(footprintGeometry["type"] as? String, "Polygon")
+        XCTAssertEqual(footprintCoordinates.first?.first, [-122.03120, 37.33160])
+        XCTAssertEqual(footprintCoordinates.first?.last, [-122.03120, 37.33160])
+
+        let levelFeature = try singleFeature(in: "level.geojson", from: entries)
+        let levelGeometry = try geometry(from: levelFeature)
+        let levelProperties = try XCTUnwrap(levelFeature["properties"] as? [String: Any])
+        XCTAssertEqual(levelGeometry["type"] as? String, "Polygon")
+        XCTAssertNotNil(levelProperties["display_point"])
+    }
+
     private func sampleVenue() -> Venue {
+        let unitCoordinates = [
+            Coordinate(latitude: 37.33170, longitude: -122.03110),
+            Coordinate(latitude: 37.33170, longitude: -122.03090),
+            Coordinate(latitude: 37.33190, longitude: -122.03090),
+            Coordinate(latitude: 37.33190, longitude: -122.03110)
+        ]
+        let footprintCoordinates = [
+            Coordinate(latitude: 37.33160, longitude: -122.03120),
+            Coordinate(latitude: 37.33160, longitude: -122.03080),
+            Coordinate(latitude: 37.33200, longitude: -122.03080),
+            Coordinate(latitude: 37.33200, longitude: -122.03120)
+        ]
+        let venueCoordinates = [
+            Coordinate(latitude: 37.33150, longitude: -122.03130),
+            Coordinate(latitude: 37.33150, longitude: -122.03070),
+            Coordinate(latitude: 37.33210, longitude: -122.03070),
+            Coordinate(latitude: 37.33210, longitude: -122.03130)
+        ]
         let unit = Unit(
             name: "Lobby",
             category: .lobby,
-            coordinates: [
-                Coordinate(latitude: 37.33170, longitude: -122.03110),
-                Coordinate(latitude: 37.33170, longitude: -122.03090),
-                Coordinate(latitude: 37.33190, longitude: -122.03090),
-                Coordinate(latitude: 37.33190, longitude: -122.03110)
-            ]
+            coordinates: unitCoordinates
         )
-        let level = Level(name: "Level 1", ordinal: 0, shortName: "1F", units: [unit])
+        let level = Level(
+            name: "Level 1",
+            category: .unspecified,
+            ordinal: 0,
+            shortName: "1F",
+            coordinates: footprintCoordinates,
+            units: [unit]
+        )
         let footprint = Footprint(
-            coordinates: [
-                Coordinate(latitude: 37.33160, longitude: -122.03120),
-                Coordinate(latitude: 37.33160, longitude: -122.03080),
-                Coordinate(latitude: 37.33200, longitude: -122.03080),
-                Coordinate(latitude: 37.33200, longitude: -122.03120)
-            ]
+            category: .ground,
+            coordinates: footprintCoordinates
         )
-        let building = Building(name: "Main Building", levels: [level], footprint: footprint)
+        let building = Building(
+            name: "Main Building",
+            category: .unspecified,
+            levels: [level],
+            footprint: footprint
+        )
         let address = Address(
             address: "1 Infinite Loop",
             locality: "Cupertino",
@@ -80,10 +151,43 @@ final class IMDFExporterTests: XCTestCase {
 
         return Venue(
             name: "IMDFlex Test Venue",
-            category: .university,
+            category: .shoppingCenter,
+            coordinates: venueCoordinates,
             buildings: [building],
             address: address
         )
+    }
+
+    private func featureCollection(
+        named fileName: String,
+        from entries: [String: Data]
+    ) throws -> [String: Any] {
+        let data = try XCTUnwrap(entries[fileName])
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func singleFeature(in fileName: String, from entries: [String: Data]) throws -> [String: Any] {
+        let collection = try featureCollection(named: fileName, from: entries)
+        let features = try XCTUnwrap(collection["features"] as? [[String: Any]])
+        return try XCTUnwrap(features.first)
+    }
+
+    private func properties(in fileName: String, from entries: [String: Data]) throws -> [String: Any] {
+        let feature = try singleFeature(in: fileName, from: entries)
+        return try XCTUnwrap(feature["properties"] as? [String: Any])
+    }
+
+    private func geometry(in fileName: String, from entries: [String: Data]) throws -> [String: Any] {
+        let feature = try singleFeature(in: fileName, from: entries)
+        return try geometry(from: feature)
+    }
+
+    private func geometry(from feature: [String: Any]) throws -> [String: Any] {
+        try XCTUnwrap(feature["geometry"] as? [String: Any])
+    }
+
+    private func polygonCoordinates(from geometry: [String: Any]) throws -> [[[Double]]] {
+        try XCTUnwrap(geometry["coordinates"] as? [[[Double]]])
     }
 }
 

--- a/IMDFlex/Projects/Domain/Sources/Entities/Building.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Building.swift
@@ -4,29 +4,52 @@ import Foundation
 public struct Building: Identifiable, Codable, Sendable {
     public let id: UUID
     public var name: String?
+    public var category: BuildingCategory
     public var levels: [Level]
     public var footprint: Footprint?
     
     public init(
         id: UUID = UUID(),
         name: String? = nil,
+        category: BuildingCategory = .unspecified,
         levels: [Level] = [],
         footprint: Footprint? = nil
     ) {
         self.id = id
         self.name = name
+        self.category = category
         self.levels = levels
         self.footprint = footprint
     }
 }
 
+public enum BuildingCategory: String, Codable, CaseIterable, Sendable {
+    case parking
+    case transit
+    case transitBus = "transit.bus"
+    case transitTrain = "transit.train"
+    case unspecified
+}
+
 /// IMDF Footprint - 건물 외곽선
 public struct Footprint: Identifiable, Codable, Sendable {
     public let id: UUID
+    public var category: FootprintCategory
     public var coordinates: [Coordinate]
     
-    public init(id: UUID = UUID(), coordinates: [Coordinate] = []) {
+    public init(
+        id: UUID = UUID(),
+        category: FootprintCategory = .ground,
+        coordinates: [Coordinate] = []
+    ) {
         self.id = id
+        self.category = category
         self.coordinates = coordinates
     }
+}
+
+public enum FootprintCategory: String, Codable, CaseIterable, Sendable {
+    case aerial
+    case ground
+    case subterranean
 }

--- a/IMDFlex/Projects/Domain/Sources/Entities/Level.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Level.swift
@@ -4,24 +4,42 @@ import Foundation
 public struct Level: Identifiable, Codable, Sendable {
     public let id: UUID
     public var name: String
+    public var category: LevelCategory
     public var ordinal: Int
     public var shortName: String?
+    public var coordinates: [Coordinate]
     public var units: [Unit]
     public var openings: [Opening]
     
     public init(
         id: UUID = UUID(),
         name: String,
+        category: LevelCategory = .unspecified,
         ordinal: Int,
         shortName: String? = nil,
+        coordinates: [Coordinate] = [],
         units: [Unit] = [],
         openings: [Opening] = []
     ) {
         self.id = id
         self.name = name
+        self.category = category
         self.ordinal = ordinal
         self.shortName = shortName
+        self.coordinates = coordinates
         self.units = units
         self.openings = openings
     }
+}
+
+public enum LevelCategory: String, Codable, CaseIterable, Sendable {
+    case arrivals
+    case domesticArrivals = "arrivals.domestic"
+    case internationalArrivals = "arrivals.intl"
+    case departures
+    case domesticDepartures = "departures.domestic"
+    case internationalDepartures = "departures.intl"
+    case parking
+    case transit
+    case unspecified
 }

--- a/IMDFlex/Projects/Domain/Sources/Entities/Venue.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Venue.swift
@@ -5,6 +5,7 @@ public struct Venue: Identifiable, Codable, Sendable {
     public let id: UUID
     public var name: String
     public var category: VenueCategory
+    public var coordinates: [Coordinate]
     public var buildings: [Building]
     public var address: Address?
     
@@ -12,12 +13,14 @@ public struct Venue: Identifiable, Codable, Sendable {
         id: UUID = UUID(),
         name: String,
         category: VenueCategory,
+        coordinates: [Coordinate] = [],
         buildings: [Building] = [],
         address: Address? = nil
     ) {
         self.id = id
         self.name = name
         self.category = category
+        self.coordinates = coordinates
         self.buildings = buildings
         self.address = address
     }
@@ -25,13 +28,25 @@ public struct Venue: Identifiable, Codable, Sendable {
 
 public enum VenueCategory: String, Codable, CaseIterable, Sendable {
     case airport
-    case shoppingCenter = "shopping_center"
-    case conventionCenter = "convention_center"
-    case hospital
+    case internationalAirport = "airport.intl"
+    case aquarium
+    case businessCampus = "businesscampus"
+    case casino
+    case communityCenter = "communitycenter"
+    case conventionCenter = "conventioncenter"
+    case governmentFacility = "governmentfacility"
+    case healthcareFacility = "healthcarefacility"
+    case hotel
     case museum
-    case parkingFacility = "parking_facility"
-    case railStation = "rail_station"
+    case parkingFacility = "parkingfacility"
+    case resort
+    case retailStore = "retailstore"
+    case shoppingCenter = "shoppingcenter"
     case stadium
+    case stripMall = "stripmall"
+    case theater
+    case themePark = "themepark"
+    case trainStation = "trainstation"
+    case transitStation = "transitstation"
     case university
-    case other
 }

--- a/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
@@ -13,17 +13,21 @@ final class DomainModelTests: XCTestCase {
         let level = Level(
             id: try uuid("00000000-0000-0000-0000-000000000002"),
             name: "Level 1",
+            category: .unspecified,
             ordinal: 0,
             shortName: "1F",
+            coordinates: squareCoordinates(),
             units: [unit]
         )
         let footprint = Footprint(
             id: try uuid("00000000-0000-0000-0000-000000000003"),
+            category: .ground,
             coordinates: squareCoordinates()
         )
         let building = Building(
             id: try uuid("00000000-0000-0000-0000-000000000004"),
             name: "Main Building",
+            category: .unspecified,
             levels: [level],
             footprint: footprint
         )
@@ -39,14 +43,20 @@ final class DomainModelTests: XCTestCase {
             id: try uuid("00000000-0000-0000-0000-000000000006"),
             name: "IMDFlex Test Venue",
             category: .university,
+            coordinates: squareCoordinates(),
             buildings: [building],
             address: address
         )
 
+        XCTAssertEqual(venue.coordinates, squareCoordinates())
         XCTAssertEqual(venue.buildings.first?.id, building.id)
+        XCTAssertEqual(venue.buildings.first?.category, .unspecified)
         XCTAssertEqual(venue.buildings.first?.levels.first?.id, level.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.category, .unspecified)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.coordinates, squareCoordinates())
         XCTAssertEqual(venue.buildings.first?.levels.first?.units.first?.id, unit.id)
         XCTAssertEqual(venue.buildings.first?.footprint?.id, footprint.id)
+        XCTAssertEqual(venue.buildings.first?.footprint?.category, .ground)
         XCTAssertEqual(venue.address?.id, address.id)
     }
 

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -13,22 +13,21 @@ This document tracks gaps between IMDFlex's current Domain/export model and Appl
 
 ## Highest-Risk Gaps
 
-### 1. Manifest Export Is Missing
+### 1. Manifest Export Is Present, Validator Confirmation Pending
 
 Apple validation includes:
 
 - `ManifestFileMustBePresent`
 - `ManifestVersionMustBeValid`
 
-Current `IMDFExporter` writes only GeoJSON feature collection files. It does not write `manifest.json`.
+Current `IMDFExporter` writes `manifest.json` with IMDF version `1.0.0`.
 
-Required direction:
+Remaining direction:
 
-- Add a manifest export file.
-- Declare the IMDF version expected by Apple resources.
-- Add tests that exported ZIP archives contain `manifest.json`.
+- Keep tests that exported ZIP archives contain `manifest.json`.
+- Confirm the generated archive in Apple IMDF Sandbox before claiming official submission readiness.
 
-### 2. Venue Geometry Is Wrong For Submission
+### 2. Venue Geometry Needs Apple Sandbox Confirmation
 
 Apple validation includes:
 
@@ -38,15 +37,15 @@ Apple validation includes:
 - `VenueMustHaveAddress`
 - `VenueMustHaveAtLeastOneBuilding`
 
-Current exporter emits `venue.geojson` with `geometry: null`.
+Current exporter emits polygonal `venue.geojson` geometry. The Domain model supports explicit venue coordinates, and the exporter falls back to an enclosing polygon derived from building footprints for legacy/project bootstrap data.
 
-Required direction:
+Remaining direction:
 
-- Add polygon geometry to the Domain `Venue` model or derive it from footprint/level coverage.
-- Add `display_point`.
+- Validate fallback-derived venue geometry in Apple IMDF Sandbox.
+- Add preflight issues for missing venue coordinates, missing address, and missing buildings.
 - Keep `address_id` and building coverage relationships valid.
 
-### 3. Level Geometry And Category Are Missing
+### 3. Level Geometry And Category Are Present, Coverage Rules Pending
 
 Apple validation includes:
 
@@ -57,16 +56,15 @@ Apple validation includes:
 - `LevelMustHaveOrdinal`
 - `LevelMustBeReferencedByUnit`
 
-Current `Level` has `name`, `ordinal`, and optional `shortName`, but no geometry or category.
+Current `Level` has `name`, `ordinal`, optional `shortName`, `category`, and polygon coordinates. The exporter falls back to the building footprint when level coordinates are not explicitly provided.
 
-Required direction:
+Remaining direction:
 
-- Add `LevelCategory`.
-- Add level polygon geometry.
 - Make `shortName` required before export or enforce it in preflight.
 - Ensure every exported level is referenced by at least one unit.
+- Validate level/footprint coverage behavior in Apple IMDF Sandbox.
 
-### 4. Building And Footprint Categories Are Missing
+### 4. Building And Footprint Categories Are Present, Relationship Preflight Pending
 
 Apple validation includes:
 
@@ -77,13 +75,12 @@ Apple validation includes:
 - `FootprintMustHavePolygonalGeometry`
 - `FootprintMustReferenceBuilding`
 
-Current `Building` has no category. Current `Footprint` has no category.
+Current `Building` has an Apple category value. Current `Footprint` has an Apple category value and polygon geometry.
 
-Required direction:
+Remaining direction:
 
-- Add `BuildingCategory` with Apple values.
-- Add `FootprintCategory` with Apple values.
 - Keep footprint-to-building references explicit in exporter and preflight validation.
+- Add preflight issues for buildings without footprints and footprints without valid polygon geometry.
 
 ### 5. Category Raw Values Do Not Match Apple IMDF
 
@@ -165,9 +162,9 @@ Use Apple category values as raw export values.
 
 ## Recommended Implementation Order
 
-1. Add `manifest.json` export and tests.
-2. Add explicit geometry/category fields for `Venue`, `Building`, `Footprint`, and `Level`.
-3. Align MVP category enums with Apple category CSV raw values.
+1. Add `manifest.json` export and tests. Done locally; Apple Sandbox confirmation pending.
+2. Add explicit geometry/category fields for `Venue`, `Building`, `Footprint`, and `Level`. Done locally; Apple Sandbox confirmation pending.
+3. Align remaining MVP category enums with Apple category CSV raw values.
 4. Add a preflight validator for required relationships and required geometry.
 5. Decide `Occupant + Anchor` scope before exporting occupants as Apple-submission data.
 6. Add module tests:


### PR DESCRIPTION
## Summary

Align core IMDF export for `venue`, `building`, `footprint`, and `level` with the highest-risk Apple validation rules identified in the schema gap audit.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added durable Domain fields for venue polygon coordinates, building category, footprint category, level category, and level polygon coordinates.
- Updated core exporter output for venue polygon geometry, display points, building/footprint/level categories, and level polygon geometry.
- Added Data tests for core feature properties, relationships, polygon geometry, and `[longitude, latitude]` coordinate order.
- Updated the IMDF schema gap document to reflect manifest/core schema progress and Apple Sandbox status.

## IMDF Impact

- Addresses local gaps tied to Apple rules such as `VenueMustHavePolygonalGeometry`, `BuildingMustHaveCategory`, `FootprintCategoryMustBeValid`, `LevelMustHaveCategory`, and `LevelMustHavePolygonalGeometry`.
- Does not claim Apple IMDF Sandbox success. The generated `imdf.zip` still needs manual official Sandbox upload/verification.
- Remaining known gaps include broader category alignment for non-core features, relationship preflight, and `Occupant`/`Anchor` scope.

## Architecture Notes

- Domain additions represent product data the editor needs to author explicitly, not Data-layer-only workarounds.
- Data exporter keeps fallback behavior for bootstrap/legacy models: venue geometry can be derived from footprint bounds, and level geometry can fall back to the building footprint.
- No new third-party dependencies were introduced.

## Verification

- [x] `Domain`: `mise exec -- tuist build Domain` succeeded; `mise exec -- tuist test Domain` succeeded with 7 tests.
- [x] `Data`: `mise exec -- tuist test Data` succeeded with 5 tests.
- [x] `Presentation`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [x] `DesignSystem`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` succeeded.
- [x] `mise exec -- tuist generate --no-binary-cache --no-open`: succeeded.
- [x] Apple IMDF Validator / preflight: Apple IMDF Sandbox was not run; PR documents this as the official manual validation step.

## Screenshots Or Recording

Not applicable; no UI changes.

## Review Notes

- Check whether the venue/level fallback geometry behavior is acceptable for MVP bootstrap data, or whether preflight should require explicit user-authored polygons sooner.
- Check whether the default core categories (`unspecified`, `ground`) are acceptable initial product defaults.
- Check that tests assert IMDF contracts and coordinate order rather than incidental implementation details.
- Check the schema gap wording: it should communicate progress without implying official Apple Sandbox approval.

## Related Issues

Closes #13

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
