### PR TITLE
test: adopt Given-When-Then conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,11 @@ IMDFlex is an Apple IMDF authoring app for iPad and Mac. It should help users cr
 ## Testing And Verification
 
 - Implement features in a testable way.
+- Follow `docs/testing-strategy.md` for test naming, Given-When-Then structure, `makeSUT()` usage, test double naming, async testing, and layer-specific strategy.
+- Use the `imdflex-test-author` skill when writing or refactoring tests.
+- Prefer XCTest for now unless an explicit Swift Testing migration decision is made.
+- Name tests with `test_whenCondition_thenExpectedBehavior`.
+- Structure test bodies with `// Given`, `// When`, and `// Then` sections separated by blank lines.
 - Add focused unit tests for domain logic, serializers, exporters, validators, and geometry behavior.
 - Prefer unit tests over UI tests unless UI tests are the only practical coverage.
 - When changing Tuist configuration, run:

--- a/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
+++ b/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
@@ -4,10 +4,16 @@ import XCTest
 import Domain
 
 final class IMDFExporterTests: XCTestCase {
-    func testExportIncludesManifestAndMVPGeoJSONFiles() async throws {
-        let archive = try await IMDFExporter().export(sampleVenue())
+    func test_whenVenueIsExported_thenArchiveIncludesManifestAndMVPGeoJSONFiles() async throws {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
+
+        // When
+        let archive = try await sut.export(venue)
         let entries = try ZipArchiveReader.entries(from: archive)
 
+        // Then
         XCTAssertEqual(
             Set(entries.keys),
             [
@@ -25,41 +31,56 @@ final class IMDFExporterTests: XCTestCase {
         )
     }
 
-    func testExportWritesIMDFManifestVersion() async throws {
-        let archive = try await IMDFExporter().export(sampleVenue())
+    func test_whenVenueIsExported_thenManifestDeclaresIMDFVersion() async throws {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
+
+        // When
+        let archive = try await sut.export(venue)
         let entries = try ZipArchiveReader.entries(from: archive)
         let manifestData = try XCTUnwrap(entries["manifest.json"])
         let manifest = try XCTUnwrap(JSONSerialization.jsonObject(with: manifestData) as? [String: Any])
 
+        // Then
         XCTAssertEqual(manifest["version"] as? String, "1.0.0")
     }
 
-    func testExportWritesVenueFeatureCollection() async throws {
-        let venue = sampleVenue()
-        let archive = try await IMDFExporter().export(venue)
+    func test_whenVenueIsExported_thenVenueGeoJSONIsFeatureCollection() async throws {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
+
+        // When
+        let archive = try await sut.export(venue)
         let entries = try ZipArchiveReader.entries(from: archive)
         let venueCollection = try featureCollection(named: "venue.geojson", from: entries)
         let features = try XCTUnwrap(venueCollection["features"] as? [[String: Any]])
         let feature = try XCTUnwrap(features.first)
 
+        // Then
         XCTAssertEqual(venueCollection["type"] as? String, "FeatureCollection")
         XCTAssertEqual(features.count, 1)
         XCTAssertEqual(feature["id"] as? String, venue.id.uuidString)
         XCTAssertEqual(feature["feature_type"] as? String, "venue")
     }
 
-    func testExportWritesCoreFeatureSchemaProperties() async throws {
-        let venue = sampleVenue()
-        let archive = try await IMDFExporter().export(venue)
-        let entries = try ZipArchiveReader.entries(from: archive)
+    func test_whenVenueIsExported_thenCoreFeaturePropertiesUseIMDFSchemaValues() async throws {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
         let building = try XCTUnwrap(venue.buildings.first)
         let level = try XCTUnwrap(building.levels.first)
 
+        // When
+        let archive = try await sut.export(venue)
+        let entries = try ZipArchiveReader.entries(from: archive)
         let venueProperties = try properties(in: "venue.geojson", from: entries)
         let buildingProperties = try properties(in: "building.geojson", from: entries)
         let footprintProperties = try properties(in: "footprint.geojson", from: entries)
         let levelProperties = try properties(in: "level.geojson", from: entries)
 
+        // Then
         XCTAssertEqual(venueProperties["category"] as? String, "shoppingcenter")
         XCTAssertEqual(venueProperties["address_id"] as? String, venue.address?.id.uuidString)
         XCTAssertEqual(buildingProperties["category"] as? String, "unspecified")
@@ -71,16 +92,21 @@ final class IMDFExporterTests: XCTestCase {
         XCTAssertEqual(levelProperties["ordinal"] as? Int, level.ordinal)
     }
 
-    func testExportWritesCorePolygonGeometryAndDisplayPoints() async throws {
-        let archive = try await IMDFExporter().export(sampleVenue())
-        let entries = try ZipArchiveReader.entries(from: archive)
+    func test_whenVenueIsExported_thenCoreFeaturesUsePolygonGeometryAndDisplayPoints() async throws {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
 
+        // When
+        let archive = try await sut.export(venue)
+        let entries = try ZipArchiveReader.entries(from: archive)
         let venueFeature = try singleFeature(in: "venue.geojson", from: entries)
         let venueGeometry = try geometry(from: venueFeature)
         let venueCoordinates = try polygonCoordinates(from: venueGeometry)
         let venueProperties = try XCTUnwrap(venueFeature["properties"] as? [String: Any])
         let venueDisplayPoint = try XCTUnwrap(venueProperties["display_point"] as? [String: Any])
 
+        // Then
         XCTAssertEqual(venueGeometry["type"] as? String, "Polygon")
         XCTAssertEqual(venueCoordinates.first?.first, [-122.03130, 37.33150])
         XCTAssertEqual(venueCoordinates.first?.last, [-122.03130, 37.33150])
@@ -99,7 +125,11 @@ final class IMDFExporterTests: XCTestCase {
         XCTAssertNotNil(levelProperties["display_point"])
     }
 
-    private func sampleVenue() -> Venue {
+    private func makeSUT() -> IMDFExporter {
+        IMDFExporter()
+    }
+
+    private func makeVenueFixture() -> Venue {
         let unitCoordinates = [
             Coordinate(latitude: 37.33170, longitude: -122.03110),
             Coordinate(latitude: 37.33170, longitude: -122.03090),

--- a/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
@@ -3,12 +3,14 @@ import XCTest
 @testable import Domain
 
 final class DomainModelTests: XCTestCase {
-    func testVenuePreservesNestedIMDFEntityRelationships() throws {
+    func test_whenVenueIsCreatedWithNestedEntities_thenItPreservesIMDFRelationships() throws {
+        // Given
+        let coordinates = squareCoordinates()
         let unit = Unit(
             id: try uuid("00000000-0000-0000-0000-000000000001"),
             name: "Lobby",
             category: .lobby,
-            coordinates: squareCoordinates()
+            coordinates: coordinates
         )
         let level = Level(
             id: try uuid("00000000-0000-0000-0000-000000000002"),
@@ -16,13 +18,13 @@ final class DomainModelTests: XCTestCase {
             category: .unspecified,
             ordinal: 0,
             shortName: "1F",
-            coordinates: squareCoordinates(),
+            coordinates: coordinates,
             units: [unit]
         )
         let footprint = Footprint(
             id: try uuid("00000000-0000-0000-0000-000000000003"),
             category: .ground,
-            coordinates: squareCoordinates()
+            coordinates: coordinates
         )
         let building = Building(
             id: try uuid("00000000-0000-0000-0000-000000000004"),
@@ -39,42 +41,75 @@ final class DomainModelTests: XCTestCase {
             country: "US",
             postalCode: "95014"
         )
+
+        // When
         let venue = Venue(
             id: try uuid("00000000-0000-0000-0000-000000000006"),
             name: "IMDFlex Test Venue",
             category: .university,
-            coordinates: squareCoordinates(),
+            coordinates: coordinates,
             buildings: [building],
             address: address
         )
 
-        XCTAssertEqual(venue.coordinates, squareCoordinates())
+        // Then
+        XCTAssertEqual(venue.coordinates, coordinates)
         XCTAssertEqual(venue.buildings.first?.id, building.id)
         XCTAssertEqual(venue.buildings.first?.category, .unspecified)
         XCTAssertEqual(venue.buildings.first?.levels.first?.id, level.id)
         XCTAssertEqual(venue.buildings.first?.levels.first?.category, .unspecified)
-        XCTAssertEqual(venue.buildings.first?.levels.first?.coordinates, squareCoordinates())
+        XCTAssertEqual(venue.buildings.first?.levels.first?.coordinates, coordinates)
         XCTAssertEqual(venue.buildings.first?.levels.first?.units.first?.id, unit.id)
         XCTAssertEqual(venue.buildings.first?.footprint?.id, footprint.id)
         XCTAssertEqual(venue.buildings.first?.footprint?.category, .ground)
         XCTAssertEqual(venue.address?.id, address.id)
     }
 
-    func testCoordinateEqualityUsesLatitudeAndLongitude() {
+    func test_whenCoordinatesShareLatitudeAndLongitude_thenTheyAreEqual() {
+        // Given
         let coordinate = Coordinate(latitude: 37.33182, longitude: -122.03118)
 
-        XCTAssertEqual(coordinate, Coordinate(latitude: 37.33182, longitude: -122.03118))
-        XCTAssertNotEqual(coordinate, Coordinate(latitude: 37.33182, longitude: -122.03119))
-        XCTAssertNotEqual(coordinate, Coordinate(latitude: 37.33183, longitude: -122.03118))
+        // When
+        let equalCoordinate = Coordinate(latitude: 37.33182, longitude: -122.03118)
+        let differentLongitude = Coordinate(latitude: 37.33182, longitude: -122.03119)
+        let differentLatitude = Coordinate(latitude: 37.33183, longitude: -122.03118)
+
+        // Then
+        XCTAssertEqual(coordinate, equalCoordinate)
+        XCTAssertNotEqual(coordinate, differentLongitude)
+        XCTAssertNotEqual(coordinate, differentLatitude)
     }
 
-    func testFootprintPreservesAuthoredPolygonCoordinates() {
+    func test_whenFootprintIsCreatedWithPolygonCoordinates_thenItPreservesAuthoredCoordinates() {
+        // Given
         let coordinates = squareCoordinates()
+
+        // When
         let footprint = Footprint(coordinates: coordinates)
 
+        // Then
         XCTAssertEqual(footprint.coordinates, coordinates)
         XCTAssertEqual(footprint.coordinates.count, 4)
         XCTAssertNotEqual(footprint.coordinates.first, footprint.coordinates.last)
+    }
+
+    func test_whenCoreCategoriesAreUsed_thenRawValuesMatchAppleIMDFCategories() {
+        // Given
+        let venueCategory = VenueCategory.shoppingCenter
+        let buildingCategory = BuildingCategory.unspecified
+        let footprintCategory = FootprintCategory.ground
+        let levelCategory = LevelCategory.unspecified
+
+        // When
+        let rawValues = [
+            venueCategory.rawValue,
+            buildingCategory.rawValue,
+            footprintCategory.rawValue,
+            levelCategory.rawValue
+        ]
+
+        // Then
+        XCTAssertEqual(rawValues, ["shoppingcenter", "unspecified", "ground", "unspecified"])
     }
 
     private func uuid(_ string: String) throws -> UUID {

--- a/IMDFlex/Projects/Domain/Tests/ProjectUseCaseTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/ProjectUseCaseTests.swift
@@ -3,36 +3,40 @@ import XCTest
 @testable import Domain
 
 final class ProjectUseCaseTests: XCTestCase {
-    func testCreateProjectSavesProjectThroughRepositoryProtocol() async throws {
-        let repository = InMemoryProjectRepository()
-        let useCase = ProjectUseCase(repository: repository)
+    func test_whenProjectIsCreated_thenItIsSavedThroughRepositoryProtocol() async throws {
+        // Given
+        let (sut, repository) = makeSUT()
 
-        let project = try await useCase.createProject(name: "Indoor Mapping")
+        // When
+        let project = try await sut.createProject(name: "Indoor Mapping")
         let savedProject = try await repository.fetch(id: project.id)
 
+        // Then
         XCTAssertEqual(savedProject?.id, project.id)
         XCTAssertEqual(savedProject?.name, "Indoor Mapping")
         XCTAssertNil(savedProject?.venue)
     }
 
-    func testLoadProjectsReturnsRepositoryProjects() async throws {
-        let repository = InMemoryProjectRepository()
-        let useCase = ProjectUseCase(repository: repository)
+    func test_whenProjectsAreLoaded_thenRepositoryProjectsAreReturned() async throws {
+        // Given
+        let (sut, repository) = makeSUT()
         let firstProject = IMDFProject(name: "First Project")
         let secondProject = IMDFProject(name: "Second Project")
 
         try await repository.save(firstProject)
         try await repository.save(secondProject)
 
-        let projects = try await useCase.loadProjects()
+        // When
+        let projects = try await sut.loadProjects()
         let projectIDs = Set(projects.map(\.id))
 
+        // Then
         XCTAssertEqual(projectIDs, [firstProject.id, secondProject.id])
     }
 
-    func testUpdateProjectRefreshesUpdatedAtAndPreservesProjectContent() async throws {
-        let repository = InMemoryProjectRepository()
-        let useCase = ProjectUseCase(repository: repository)
+    func test_whenProjectIsUpdated_thenUpdatedAtIsRefreshedAndContentIsPreserved() async throws {
+        // Given
+        let (sut, repository) = makeSUT()
         let createdAt = Date(timeIntervalSince1970: 100)
         let oldUpdatedAt = Date(timeIntervalSince1970: 200)
         let venue = Venue(name: "Venue", category: .university)
@@ -43,8 +47,10 @@ final class ProjectUseCaseTests: XCTestCase {
             updatedAt: oldUpdatedAt
         )
 
-        try await useCase.updateProject(project)
+        // When
+        try await sut.updateProject(project)
 
+        // Then
         let fetchedProject = try await repository.fetch(id: project.id)
         let updatedProject = try XCTUnwrap(fetchedProject)
         XCTAssertEqual(updatedProject.id, project.id)
@@ -54,20 +60,29 @@ final class ProjectUseCaseTests: XCTestCase {
         XCTAssertGreaterThan(updatedProject.updatedAt, oldUpdatedAt)
     }
 
-    func testDeleteProjectRemovesProjectThroughRepositoryProtocol() async throws {
-        let repository = InMemoryProjectRepository()
-        let useCase = ProjectUseCase(repository: repository)
+    func test_whenProjectIsDeleted_thenItIsRemovedThroughRepositoryProtocol() async throws {
+        // Given
+        let (sut, repository) = makeSUT()
         let project = IMDFProject(name: "Project To Delete")
-
         try await repository.save(project)
-        try await useCase.deleteProject(id: project.id)
 
+        // When
+        try await sut.deleteProject(id: project.id)
         let deletedProject = try await repository.fetch(id: project.id)
+
+        // Then
         XCTAssertNil(deletedProject)
+    }
+
+    private func makeSUT() -> (sut: ProjectUseCase, repository: InMemoryProjectRepositoryFake) {
+        let repository = InMemoryProjectRepositoryFake()
+        let sut = ProjectUseCase(repository: repository)
+
+        return (sut, repository)
     }
 }
 
-private actor InMemoryProjectRepository: ProjectRepositoryProtocol {
+private actor InMemoryProjectRepositoryFake: ProjectRepositoryProtocol {
     private var projects: [UUID: IMDFProject] = [:]
 
     func fetchAll() async throws -> [IMDFProject] {

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,149 @@
+# Testing Strategy
+
+This document defines how IMDFlex tests should be written and reviewed.
+
+## Goals
+
+IMDFlex tests should be valuable, fast, independent, repeatable, self-validating, and useful as executable documentation. Prefer a smaller set of meaningful tests over broad coverage that is tightly coupled to implementation details.
+
+Use tests to protect the parts of the product that are hardest to verify manually:
+
+- IMDF Domain model contracts and relationships.
+- GeoJSON serialization and coordinate order.
+- ZIP export structure.
+- Preflight validation rules.
+- Drawing/editor state transitions once Presentation models are introduced.
+
+## Framework
+
+Use XCTest for now. IMDFlex targets iOS 18+ and Swift 6+, so Swift Testing can be revisited later, but do not mix frameworks casually inside the same module without an explicit migration decision.
+
+## Naming
+
+Use `test_whenCondition_thenExpectedBehavior`.
+
+Examples:
+
+```swift
+func test_whenVenueIsExported_thenArchiveIncludesManifestAndMVPGeoJSONFiles() async throws
+func test_whenProjectIsUpdated_thenUpdatedAtIsRefreshedAndContentIsPreserved() async throws
+```
+
+Avoid names such as `testExport()` or `testAdd()`. The test name should explain the failure before opening the file.
+
+## Given-When-Then
+
+Structure XCTest bodies with comments and blank lines:
+
+```swift
+func test_whenItemIsAdded_thenCountIncreasesByOne() {
+    // Given
+    let sut = makeSUT()
+    let item = Item.fixture()
+
+    // When
+    sut.add(item)
+
+    // Then
+    XCTAssertEqual(sut.items.count, 1)
+}
+```
+
+Prefer this style over wrapping every phase in helper functions. Helpers are useful, but they should not hide the facts that make the scenario meaningful.
+
+## makeSUT
+
+Use `makeSUT()` for the primary system under test and default collaborators:
+
+```swift
+private func makeSUT(
+    repository: ProjectRepositoryProtocol = InMemoryProjectRepositoryFake()
+) -> ProjectUseCase {
+    ProjectUseCase(repository: repository)
+}
+```
+
+When the test needs both the SUT and a collaborator for assertions, returning a labeled tuple is acceptable:
+
+```swift
+private func makeSUT() -> (sut: ProjectUseCase, repository: InMemoryProjectRepositoryFake)
+```
+
+Use memory leak tracking for class-based SUTs when lifecycle risk appears:
+
+```swift
+func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+    addTeardownBlock { [weak instance] in
+        XCTAssertNil(instance, "Expected instance to be deallocated.", file: file, line: line)
+    }
+}
+```
+
+## Test Doubles
+
+Name test doubles precisely:
+
+- `Stub`: returns prepared values.
+- `Spy`: records calls, counts, or arguments.
+- `Mock`: verifies expected interactions.
+- `Fake`: lightweight working implementation unsuitable for production.
+
+Do not call every test double a mock. Prefer real Domain objects when they keep the test simpler and more realistic.
+
+## Layer Strategy
+
+### Domain
+
+Test pure entities, value semantics, category raw values, geometry rules, and use case contracts. Mocking should be rare. In-memory fakes are acceptable for protocol-backed use cases.
+
+### Data
+
+Test repository behavior, serializers, exporters, ZIP structure, GeoJSON shape, category raw values, relationship IDs, and coordinate order. These tests should assert IMDF contracts, not private implementation details.
+
+### Presentation
+
+Test observable state models, coordinators, editor state machines, drawing tools, and async user flows. Public APIs should be awaitable whenever possible. Avoid hidden `Task {}` timing that forces sleeps or flaky expectations.
+
+### DesignSystem And App
+
+Prefer build verification unless there is meaningful behavior to test. Snapshot testing for SwiftUI views can be considered later with explicit dependency approval.
+
+## Async Tests
+
+Prefer awaitable public APIs:
+
+```swift
+await sut.loadVenues()
+XCTAssertEqual(sut.venues.count, 3)
+```
+
+Avoid tests that assert immediately after starting hidden work:
+
+```swift
+sut.loadVenues()
+XCTAssertEqual(sut.venues.count, 3)
+```
+
+If behavior depends on time, inject a clock rather than using sleeps.
+
+## Contract Tests
+
+When multiple production implementations conform to the same protocol, add shared contract tests where practical. This is especially useful for repositories, exporters, validators, and cache-backed data sources.
+
+## TestSupport Module
+
+Do not add a shared TestSupport module yet. Once Domain/Data/Presentation tests start duplicating fixtures, ZIP readers, geometry assertions, memory leak tracking, or test doubles, create a dedicated Tuist `TestSupport` module and move shared test-only helpers there.
+
+Until then, keep helpers private to their test file or test target.
+
+## Verification
+
+Report verification by module in PRs:
+
+- `Domain`: tested or not run, with reason.
+- `Data`: tested or not run, with reason.
+- `Presentation`: tested or not run, with reason.
+- `DesignSystem`: tested or not run, with reason.
+- `App`: built or not run, with reason.
+
+When Apple IMDF export behavior changes, local tests are not enough. State whether Apple IMDF Sandbox / Validator was run manually.


### PR DESCRIPTION
## Summary

Refactor existing tests to use a Swift-friendly Given-When-Then style and document the IMDFlex testing strategy.

## Type

- [ ] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [x] `test:` tests only

## Changes

- Renamed existing Domain/Data tests to `test_whenCondition_thenExpectedBehavior`.
- Reorganized test bodies with `// Given`, `// When`, and `// Then` sections.
- Added `makeSUT()` usage where it improves setup clarity.
- Renamed the in-memory repository test double to `InMemoryProjectRepositoryFake`.
- Added `docs/testing-strategy.md` and linked it from `AGENTS.md`.
- Created local Codex skill `imdflex-test-author` for future test-writing/refactoring guidance.

## IMDF Impact

- No production IMDF export behavior changes.
- Existing exporter and Domain tests continue to cover manifest, core GeoJSON structure, category raw values, relationships, and coordinate order.

## Architecture Notes

- No production source changes.
- The shared `TestSupport` module is intentionally deferred and documented for future work.
- XCTest remains the current test framework; Swift Testing migration is documented as a later explicit decision.

## Verification

- [x] `Domain`: `mise exec -- tuist test Domain` succeeded with 8 tests.
- [x] `Data`: `mise exec -- tuist test Data` succeeded with 5 tests.
- [x] `Presentation`: Not run directly; no Presentation changes.
- [x] `DesignSystem`: Not run directly; no DesignSystem changes.
- [x] `App`: `mise exec -- tuist build IMDFlex` succeeded.
- [x] `mise exec -- tuist generate --no-binary-cache --no-open`: Not run; no Tuist manifest changes.
- [x] Apple IMDF Validator / preflight: Not applicable; tests/docs-only change.

## Screenshots Or Recording

Not applicable; no UI changes.

## Review Notes

- Check whether the GWT comments improve readability without adding noise.
- Check whether the new test names are descriptive enough in failure output.
- Check whether `docs/testing-strategy.md` is actionable for future Domain, Data, Presentation, and preflight tests.
- Check whether deferring a shared `TestSupport` module is still the right scope for this PR.

## Related Issues

Closes #15

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
