### PR TITLE
feat: add IMDF preflight validator

### DIFF
--- a/IMDFlex/Projects/Domain/Sources/UseCases/IMDFPreflightValidator.swift
+++ b/IMDFlex/Projects/Domain/Sources/UseCases/IMDFPreflightValidator.swift
@@ -1,0 +1,250 @@
+import Foundation
+
+public protocol IMDFPreflightValidating: Sendable {
+    func validate(_ venue: Venue) -> [IMDFPreflightIssue]
+}
+
+public struct IMDFPreflightValidator: IMDFPreflightValidating, Sendable {
+    public init() {}
+
+    public func validate(_ venue: Venue) -> [IMDFPreflightIssue] {
+        var issues: [IMDFPreflightIssue] = []
+
+        validateVenue(venue, issues: &issues)
+
+        for building in venue.buildings {
+            validateBuilding(building, issues: &issues)
+
+            for level in building.levels {
+                validateLevel(level, building: building, issues: &issues)
+                validateUnits(in: level, issues: &issues)
+            }
+        }
+
+        return issues
+    }
+
+    private func validateVenue(_ venue: Venue, issues: inout [IMDFPreflightIssue]) {
+        if !isValidPolygon(venue.coordinates) {
+            issues.append(
+                .init(
+                    code: .venueMissingPolygon,
+                    severity: .warning,
+                    feature: .venue,
+                    featureID: venue.id,
+                    message: "Venue should have an explicit polygon before Apple IMDF Sandbox validation."
+                )
+            )
+        }
+
+        if venue.address == nil {
+            issues.append(
+                .init(
+                    code: .venueMissingAddress,
+                    severity: .error,
+                    feature: .venue,
+                    featureID: venue.id,
+                    message: "Venue must reference an address."
+                )
+            )
+        }
+
+        if venue.buildings.isEmpty {
+            issues.append(
+                .init(
+                    code: .venueMissingBuilding,
+                    severity: .error,
+                    feature: .venue,
+                    featureID: venue.id,
+                    message: "Venue must contain at least one building."
+                )
+            )
+        }
+    }
+
+    private func validateBuilding(_ building: Building, issues: inout [IMDFPreflightIssue]) {
+        guard let footprint = building.footprint else {
+            issues.append(
+                .init(
+                    code: .buildingMissingFootprint,
+                    severity: .error,
+                    feature: .building,
+                    featureID: building.id,
+                    message: "Building must have at least one footprint."
+                )
+            )
+            return
+        }
+
+        if !isValidPolygon(footprint.coordinates) {
+            issues.append(
+                .init(
+                    code: .footprintInvalidPolygon,
+                    severity: .error,
+                    feature: .footprint,
+                    featureID: footprint.id,
+                    message: "Footprint must have at least three polygon coordinates."
+                )
+            )
+        }
+    }
+
+    private func validateLevel(
+        _ level: Level,
+        building: Building,
+        issues: inout [IMDFPreflightIssue]
+    ) {
+        if level.shortName?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true {
+            issues.append(
+                .init(
+                    code: .levelMissingShortName,
+                    severity: .error,
+                    feature: .level,
+                    featureID: level.id,
+                    message: "Level must have a short name."
+                )
+            )
+        }
+
+        let hasLevelPolygon = isValidPolygon(level.coordinates)
+        let hasFootprintFallback = building.footprint.map { isValidPolygon($0.coordinates) } ?? false
+
+        if !hasLevelPolygon && !hasFootprintFallback {
+            issues.append(
+                .init(
+                    code: .levelMissingPolygon,
+                    severity: .error,
+                    feature: .level,
+                    featureID: level.id,
+                    message: "Level must have polygon coordinates or a valid building footprint fallback."
+                )
+            )
+        }
+
+        if level.units.isEmpty {
+            issues.append(
+                .init(
+                    code: .levelMissingUnit,
+                    severity: .error,
+                    feature: .level,
+                    featureID: level.id,
+                    message: "Level must be referenced by at least one unit."
+                )
+            )
+        }
+    }
+
+    private func validateUnits(in level: Level, issues: inout [IMDFPreflightIssue]) {
+        for unit in level.units {
+            if !isValidPolygon(unit.coordinates) {
+                issues.append(
+                    .init(
+                        code: .unitInvalidPolygon,
+                        severity: .error,
+                        feature: .unit,
+                        featureID: unit.id,
+                        message: "Unit must have at least three polygon coordinates."
+                    )
+                )
+            }
+
+            for occupant in unit.occupants {
+                validateOccupant(occupant, issues: &issues)
+            }
+        }
+    }
+
+    private func validateOccupant(_ occupant: Occupant, issues: inout [IMDFPreflightIssue]) {
+        if occupant.category == nil {
+            issues.append(
+                .init(
+                    code: .occupantMissingCategory,
+                    severity: .error,
+                    feature: .occupant,
+                    featureID: occupant.id,
+                    message: "Occupant must have a category."
+                )
+            )
+        }
+
+        issues.append(
+            .init(
+                code: .occupantAnchorUnsupported,
+                severity: .error,
+                feature: .occupant,
+                featureID: occupant.id,
+                message: "Occupant export requires anchor support, which is not implemented yet."
+            )
+        )
+    }
+
+    private func isValidPolygon(_ coordinates: [Coordinate]) -> Bool {
+        uniqueCoordinates(in: coordinates).count >= 3
+    }
+
+    private func uniqueCoordinates(in coordinates: [Coordinate]) -> [Coordinate] {
+        coordinates.reduce(into: []) { result, coordinate in
+            if !result.contains(coordinate) {
+                result.append(coordinate)
+            }
+        }
+    }
+}
+
+public struct IMDFPreflightIssue: Identifiable, Equatable, Sendable {
+    public let code: IMDFPreflightIssueCode
+    public let severity: IMDFPreflightSeverity
+    public let feature: IMDFPreflightFeature
+    public let featureID: UUID?
+    public let message: String
+
+    public var id: String {
+        [
+            code.rawValue,
+            feature.rawValue,
+            featureID?.uuidString ?? "archive"
+        ].joined(separator: ":")
+    }
+
+    public init(
+        code: IMDFPreflightIssueCode,
+        severity: IMDFPreflightSeverity,
+        feature: IMDFPreflightFeature,
+        featureID: UUID?,
+        message: String
+    ) {
+        self.code = code
+        self.severity = severity
+        self.feature = feature
+        self.featureID = featureID
+        self.message = message
+    }
+}
+
+public enum IMDFPreflightIssueCode: String, Codable, CaseIterable, Sendable {
+    case venueMissingPolygon
+    case venueMissingAddress
+    case venueMissingBuilding
+    case buildingMissingFootprint
+    case footprintInvalidPolygon
+    case levelMissingShortName
+    case levelMissingPolygon
+    case levelMissingUnit
+    case unitInvalidPolygon
+    case occupantMissingCategory
+    case occupantAnchorUnsupported
+}
+
+public enum IMDFPreflightSeverity: String, Codable, CaseIterable, Sendable {
+    case warning
+    case error
+}
+
+public enum IMDFPreflightFeature: String, Codable, CaseIterable, Sendable {
+    case venue
+    case building
+    case footprint
+    case level
+    case unit
+    case occupant
+}

--- a/IMDFlex/Projects/Domain/Tests/IMDFPreflightValidatorTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/IMDFPreflightValidatorTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import XCTest
+@testable import Domain
+
+final class IMDFPreflightValidatorTests: XCTestCase {
+    func test_whenVenueHasRequiredMVPData_thenValidatorReturnsNoIssues() {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertTrue(issues.isEmpty)
+    }
+
+    func test_whenVenueMissesTopLevelRequirements_thenValidatorReturnsVenueIssues() {
+        // Given
+        let sut = makeSUT()
+        let venue = Venue(
+            name: "Invalid Venue",
+            category: .university,
+            coordinates: []
+        )
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertEqual(issueCodes(in: issues), [.venueMissingPolygon, .venueMissingAddress, .venueMissingBuilding])
+        XCTAssertTrue(issues.allSatisfy { $0.feature == .venue })
+    }
+
+    func test_whenBuildingAndFootprintAreInvalid_thenValidatorReturnsBuildingAndFootprintIssues() {
+        // Given
+        let sut = makeSUT()
+        let buildingWithoutFootprint = Building(name: "Missing Footprint")
+        let buildingWithInvalidFootprint = Building(
+            name: "Invalid Footprint",
+            footprint: Footprint(coordinates: [Coordinate(latitude: 37.0, longitude: -122.0)])
+        )
+        let venue = makeVenueFixture(buildings: [buildingWithoutFootprint, buildingWithInvalidFootprint])
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertEqual(issueCodes(in: issues), [.buildingMissingFootprint, .footprintInvalidPolygon])
+        XCTAssertEqual(issues.map(\.feature), [.building, .footprint])
+    }
+
+    func test_whenLevelIsMissingRequiredExportData_thenValidatorReturnsLevelIssues() {
+        // Given
+        let sut = makeSUT()
+        let level = Level(
+            name: "Level 1",
+            ordinal: 0,
+            shortName: " ",
+            coordinates: [],
+            units: []
+        )
+        let building = Building(name: "Main", levels: [level], footprint: nil)
+        let venue = makeVenueFixture(buildings: [building])
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertEqual(
+            issueCodes(in: issues),
+            [.buildingMissingFootprint, .levelMissingShortName, .levelMissingPolygon, .levelMissingUnit]
+        )
+        XCTAssertTrue(issues.contains { $0.feature == .level && $0.featureID == level.id })
+    }
+
+    func test_whenLevelHasNoCoordinatesButBuildingHasValidFootprint_thenValidatorAcceptsFallbackGeometry() {
+        // Given
+        let sut = makeSUT()
+        let level = Level(
+            name: "Level 1",
+            ordinal: 0,
+            shortName: "1F",
+            coordinates: [],
+            units: [makeUnitFixture()]
+        )
+        let building = Building(name: "Main", levels: [level], footprint: makeFootprintFixture())
+        let venue = makeVenueFixture(buildings: [building])
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertFalse(issues.contains { $0.code == .levelMissingPolygon })
+    }
+
+    func test_whenUnitAndOccupantAreInvalid_thenValidatorReturnsUnitAndOccupantIssues() {
+        // Given
+        let sut = makeSUT()
+        let occupant = Occupant(name: "Tenant")
+        let unit = Domain.Unit(
+            name: "Invalid Unit",
+            category: .room,
+            coordinates: [],
+            occupants: [occupant]
+        )
+        let level = Level(
+            name: "Level 1",
+            ordinal: 0,
+            shortName: "1F",
+            coordinates: squareCoordinates(),
+            units: [unit]
+        )
+        let building = Building(name: "Main", levels: [level], footprint: makeFootprintFixture())
+        let venue = makeVenueFixture(buildings: [building])
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertEqual(issueCodes(in: issues), [.unitInvalidPolygon, .occupantMissingCategory, .occupantAnchorUnsupported])
+        XCTAssertEqual(issues.map(\.feature), [.unit, .occupant, .occupant])
+        XCTAssertTrue(issues.contains { $0.featureID == occupant.id })
+    }
+
+    func test_whenIssueIsCreated_thenIDIncludesCodeFeatureAndFeatureID() throws {
+        // Given
+        let featureID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000017"))
+        let issue = IMDFPreflightIssue(
+            code: .venueMissingAddress,
+            severity: .error,
+            feature: .venue,
+            featureID: featureID,
+            message: "Venue must reference an address."
+        )
+
+        // When
+        let id = issue.id
+
+        // Then
+        XCTAssertEqual(id, "venueMissingAddress:venue:00000000-0000-0000-0000-000000000017")
+    }
+
+    private func makeSUT() -> IMDFPreflightValidator {
+        IMDFPreflightValidator()
+    }
+
+    private func makeVenueFixture(buildings: [Building]? = nil) -> Venue {
+        Venue(
+            name: "Valid Venue",
+            category: .university,
+            coordinates: squareCoordinates(),
+            buildings: buildings ?? [makeBuildingFixture()],
+            address: Address(
+                address: "1 Infinite Loop",
+                locality: "Cupertino",
+                province: "CA",
+                country: "US",
+                postalCode: "95014"
+            )
+        )
+    }
+
+    private func makeBuildingFixture() -> Building {
+        Building(
+            name: "Main",
+            levels: [
+                Level(
+                    name: "Level 1",
+                    ordinal: 0,
+                    shortName: "1F",
+                    coordinates: squareCoordinates(),
+                    units: [makeUnitFixture()]
+                )
+            ],
+            footprint: makeFootprintFixture()
+        )
+    }
+
+    private func makeFootprintFixture() -> Footprint {
+        Footprint(coordinates: squareCoordinates())
+    }
+
+    private func makeUnitFixture() -> Domain.Unit {
+        Domain.Unit(name: "Lobby", category: .lobby, coordinates: squareCoordinates())
+    }
+
+    private func squareCoordinates() -> [Coordinate] {
+        [
+            Coordinate(latitude: 37.33170, longitude: -122.03110),
+            Coordinate(latitude: 37.33170, longitude: -122.03090),
+            Coordinate(latitude: 37.33190, longitude: -122.03090),
+            Coordinate(latitude: 37.33190, longitude: -122.03110)
+        ]
+    }
+
+    private func issueCodes(in issues: [IMDFPreflightIssue]) -> [IMDFPreflightIssueCode] {
+        issues.map(\.code)
+    }
+}

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -165,13 +165,38 @@ Use Apple category values as raw export values.
 1. Add `manifest.json` export and tests. Done locally; Apple Sandbox confirmation pending.
 2. Add explicit geometry/category fields for `Venue`, `Building`, `Footprint`, and `Level`. Done locally; Apple Sandbox confirmation pending.
 3. Align remaining MVP category enums with Apple category CSV raw values.
-4. Add a preflight validator for required relationships and required geometry.
+4. Add a preflight validator for required relationships and required geometry. Started locally with model-level required data checks.
 5. Decide `Occupant + Anchor` scope before exporting occupants as Apple-submission data.
 6. Add module tests:
    - `Domain`: entity construction and category raw values.
    - `Data`: exported ZIP file list and GeoJSON structure.
    - `Data`: relationship references and coordinate order.
    - `Presentation`: later, editor tools should produce valid Domain geometry.
+
+## Local Preflight Scope
+
+`IMDFPreflightValidator` is a local authoring aid, not a replacement for Apple IMDF Sandbox or Apple IMDF Validator.
+
+The first local preflight pass checks model-level issues that can be detected without full GeoJSON topology:
+
+- Venue has explicit polygon coordinates.
+- Venue references an address.
+- Venue has at least one building.
+- Building has a footprint.
+- Footprint has enough coordinates to form a polygon.
+- Level has a short name.
+- Level has explicit polygon coordinates or a valid building footprint fallback.
+- Level has at least one unit.
+- Unit has enough coordinates to form a polygon.
+- Occupant has a category.
+- Occupant export is blocked until anchor support exists.
+
+The preflight validator intentionally does not yet prove:
+
+- Venue polygon covers all child features.
+- Display points are contained by their parent polygons.
+- Level/unit/footprint coverage is topologically correct.
+- Apple IMDF Sandbox acceptance.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

Add the first Domain-level IMDF preflight validator for likely Apple IMDF validation issues before export/Sandbox upload.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added `IMDFPreflightValidating`, `IMDFPreflightValidator`, issue codes, severities, feature context, and stable issue IDs in Domain.
- Added model-level checks for venue, building, footprint, level, unit, and occupant readiness.
- Added GWT-style Domain tests for valid and invalid MVP scenarios.
- Documented local preflight scope and limitations in `docs/imdf-schema-gap.md`.

## IMDF Impact

- Provides local authoring guidance for required model data and relationship gaps before Apple IMDF Sandbox validation.
- Does not claim Apple IMDF Sandbox or Validator equivalence.
- Does not perform full topology checks such as venue coverage, display point containment, or unit/level area equality.

## Architecture Notes

- Validator lives in `Domain` and depends only on Domain models.
- Issue model includes stable code, severity, feature type, and optional feature ID so Presentation can later route users back to affected features.
- Occupants currently always produce `occupantAnchorUnsupported` because `Anchor` is not implemented yet.

## Verification

- [x] `Domain`: `mise exec -- tuist test Domain` succeeded with 15 tests.
- [x] `Data`: `mise exec -- tuist test Data` succeeded with 5 tests.
- [x] `Presentation`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [x] `DesignSystem`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` succeeded.
- [x] `mise exec -- tuist generate --no-binary-cache --no-open`: Not run; no Tuist manifest changes.
- [ ] Apple IMDF Validator / preflight: Apple IMDF Sandbox was not run; this PR adds local preflight only.

## Screenshots Or Recording

Not applicable; no UI changes.

## Review Notes

- Check whether warning vs error severity is right for explicit venue polygon coordinates, since exporter currently has a footprint-derived fallback.
- Check whether issue codes and feature context are stable enough for future UI routing.
- Check whether the first rule set is useful without overclaiming Apple Sandbox equivalence.
- Check whether occupant handling should remain an error until `Anchor` support is implemented.

## Related Issues

Closes #17

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
