### PR TITLE
fix: align IMDF category raw values

### DIFF
--- a/IMDFlex/Projects/Domain/Sources/Entities/Amenity.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Amenity.swift
@@ -26,14 +26,14 @@ public enum AmenityCategory: String, Codable, CaseIterable, Sendable {
     case escalator
     case stairs
     case restroom
-    case restroomMale = "restroom_male"
-    case restroomFemale = "restroom_female"
-    case restroomUnisex = "restroom_unisex"
-    case drinkingWater = "drinking_water"
+    case restroomMale = "restroom.male"
+    case restroomFemale = "restroom.female"
+    case restroomUnisex = "restroom.unisex"
+    case drinkingWater = "drinkingfountain"
     case information
-    case ticketMachine = "ticket_machine"
+    case ticketMachine = "ticketing"
     case parking
-    case chargingStation = "charging_station"
-    case firstAid = "first_aid"
-    case other
+    case chargingStation = "powerchargingstation"
+    case firstAid = "firstaid"
+    case unspecified
 }

--- a/IMDFlex/Projects/Domain/Sources/Entities/Occupant.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Occupant.swift
@@ -27,15 +27,14 @@ public struct Occupant: Identifiable, Codable, Sendable {
 }
 
 public enum OccupantCategory: String, Codable, CaseIterable, Sendable {
-    case retail
+    case retail = "shopping"
     case restaurant
     case cafe
     case bank
-    case office
-    case medical
-    case government
+    case office = "corporateoffices"
+    case medical = "medicalcenter"
+    case government = "publicservices.government"
     case education
-    case entertainment
-    case service
-    case other
+    case entertainment = "arts.entertainment"
+    case service = "localservices"
 }

--- a/IMDFlex/Projects/Domain/Sources/Entities/Opening.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Opening.swift
@@ -21,19 +21,22 @@ public struct Opening: Identifiable, Codable, Sendable {
 }
 
 public enum OpeningCategory: String, Codable, CaseIterable, Sendable {
-    case door
-    case emergencyDoor = "emergency_door"
-    case gate
-    case entrance
-    case exit
-    case emergencyExit = "emergency_exit"
-    case other
+    case automobile
+    case bicycle
+    case emergencyExit = "emergencyexit"
+    case pedestrian
+    case principalPedestrian = "pedestrian.principal"
+    case transitPedestrian = "pedestrian.transit"
+    case service
 }
 
 public enum AccessControl: String, Codable, CaseIterable, Sendable {
-    case open
-    case restricted
-    case locked
-    case keyCard = "key_card"
-    case biometric
+    case badgeReader = "badgereader"
+    case fingerprintReader = "fingerprintreader"
+    case guarded = "guard"
+    case keyAccess = "keyaccess"
+    case outOfService = "outofservice"
+    case passwordAccess = "passwordaccess"
+    case retinaScanner = "retinascanner"
+    case voiceRecognition = "voicerecognition"
 }

--- a/IMDFlex/Projects/Domain/Sources/Entities/Unit.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Unit.swift
@@ -28,7 +28,7 @@ public struct Unit: Identifiable, Codable, Sendable {
 
 public enum UnitCategory: String, Codable, CaseIterable, Sendable {
     case room
-    case corridor
+    case walkway
     case lobby
     case restroom
     case stairs
@@ -36,9 +36,8 @@ public enum UnitCategory: String, Codable, CaseIterable, Sendable {
     case escalator
     case parking
     case office
-    case retail
-    case foodService = "food_service"
+    case foodService = "foodservice"
     case storage
-    case mechanical
-    case other
+    case structure
+    case unspecified
 }

--- a/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
@@ -93,23 +93,59 @@ final class DomainModelTests: XCTestCase {
         XCTAssertNotEqual(footprint.coordinates.first, footprint.coordinates.last)
     }
 
-    func test_whenCoreCategoriesAreUsed_thenRawValuesMatchAppleIMDFCategories() {
+    func test_whenMVPFeatureCategoriesAreUsed_thenRawValuesMatchAppleIMDFCategories() {
         // Given
-        let venueCategory = VenueCategory.shoppingCenter
-        let buildingCategory = BuildingCategory.unspecified
-        let footprintCategory = FootprintCategory.ground
-        let levelCategory = LevelCategory.unspecified
+        let categories: [String] = [
+            VenueCategory.shoppingCenter.rawValue,
+            BuildingCategory.unspecified.rawValue,
+            FootprintCategory.ground.rawValue,
+            LevelCategory.unspecified.rawValue,
+            UnitCategory.foodService.rawValue,
+            UnitCategory.walkway.rawValue,
+            UnitCategory.structure.rawValue,
+            OpeningCategory.emergencyExit.rawValue,
+            OpeningCategory.principalPedestrian.rawValue,
+            AccessControl.keyAccess.rawValue,
+            AccessControl.badgeReader.rawValue,
+            AmenityCategory.restroomMale.rawValue,
+            AmenityCategory.drinkingWater.rawValue,
+            AmenityCategory.chargingStation.rawValue,
+            AmenityCategory.firstAid.rawValue,
+            OccupantCategory.retail.rawValue,
+            OccupantCategory.office.rawValue,
+            OccupantCategory.medical.rawValue,
+            OccupantCategory.government.rawValue,
+            OccupantCategory.entertainment.rawValue,
+            OccupantCategory.service.rawValue
+        ]
 
         // When
-        let rawValues = [
-            venueCategory.rawValue,
-            buildingCategory.rawValue,
-            footprintCategory.rawValue,
-            levelCategory.rawValue
+        let expectedAppleCategoryValues = [
+            "shoppingcenter",
+            "unspecified",
+            "ground",
+            "unspecified",
+            "foodservice",
+            "walkway",
+            "structure",
+            "emergencyexit",
+            "pedestrian.principal",
+            "keyaccess",
+            "badgereader",
+            "restroom.male",
+            "drinkingfountain",
+            "powerchargingstation",
+            "firstaid",
+            "shopping",
+            "corporateoffices",
+            "medicalcenter",
+            "publicservices.government",
+            "arts.entertainment",
+            "localservices"
         ]
 
         // Then
-        XCTAssertEqual(rawValues, ["shoppingcenter", "unspecified", "ground", "unspecified"])
+        XCTAssertEqual(categories, expectedAppleCategoryValues)
     }
 
     private func uuid(_ string: String) throws -> UUID {

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -82,23 +82,25 @@ Remaining direction:
 - Keep footprint-to-building references explicit in exporter and preflight validation.
 - Add preflight issues for buildings without footprints and footprints without valid polygon geometry.
 
-### 5. Category Raw Values Do Not Match Apple IMDF
+### 5. Remaining Category Coverage Needs Apple IMDF Review
 
-Several current enums use app-friendly or snake_case values that are not Apple IMDF raw values.
+MVP category enum raw values are being aligned to Apple IMDF values. Core categories and curated MVP presets for `Unit`, `Opening`, `AccessControl`, `Amenity`, and `Occupant` now use Apple category CSV values where represented.
 
-Examples:
+Resolved examples:
 
-- `VenueCategory.shoppingCenter` currently exports `shopping_center`; Apple category is `shoppingcenter`.
-- `VenueCategory.parkingFacility` currently exports `parking_facility`; Apple category is `parkingfacility`.
-- `UnitCategory.foodService` currently exports `food_service`; Apple category is `foodservice`.
-- `OpeningCategory.emergencyExit` currently exports `emergency_exit`; Apple category is `emergencyexit`.
-- `AccessControl.keyCard` currently exports `key_card`; Apple category list uses values such as `keyaccess`, `badgereader`, and `passwordaccess`.
+- `VenueCategory.shoppingCenter` exports `shoppingcenter`.
+- `VenueCategory.parkingFacility` exports `parkingfacility`.
+- `UnitCategory.foodService` exports `foodservice`.
+- `OpeningCategory.emergencyExit` exports `emergencyexit`.
+- `AccessControl.keyAccess` exports `keyaccess`.
+- Amenity presets use Apple compact/dot values such as `restroom.male`, `drinkingfountain`, `powerchargingstation`, and `firstaid`.
+- Occupant presets map to Apple category values such as `shopping`, `corporateoffices`, `medicalcenter`, `publicservices.government`, `arts.entertainment`, and `localservices`.
 
-Required direction:
+Remaining direction:
 
-- Replace or remap enum raw values to Apple CSV values.
-- Consider keeping user-facing labels separate from IMDF raw values.
-- Add tests asserting exported raw values match Apple categories.
+- Decide whether full Apple category lists should be modeled as enums, raw strings, or curated presets.
+- Add UI-facing labels separate from IMDF raw values.
+- Continue adding tests when new category presets are introduced.
 
 ### 6. Occupant Requires Anchor
 
@@ -164,7 +166,7 @@ Use Apple category values as raw export values.
 
 1. Add `manifest.json` export and tests. Done locally; Apple Sandbox confirmation pending.
 2. Add explicit geometry/category fields for `Venue`, `Building`, `Footprint`, and `Level`. Done locally; Apple Sandbox confirmation pending.
-3. Align remaining MVP category enums with Apple category CSV raw values.
+3. Align remaining MVP category enums with Apple category CSV raw values. Curated MVP presets are aligned locally; full category strategy remains open.
 4. Add a preflight validator for required relationships and required geometry. Started locally with model-level required data checks.
 5. Decide `Occupant + Anchor` scope before exporting occupants as Apple-submission data.
 6. Add module tests:


### PR DESCRIPTION
## Summary

Align remaining MVP IMDF category raw values with Apple's IMDF category CSV.

## Type

- [ ] `feat:` user-facing feature
- [x] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Updated `UnitCategory` raw values and presets to Apple values such as `foodservice`, `walkway`, `structure`, and `unspecified`.
- Replaced `OpeningCategory` with Apple opening categories.
- Replaced `AccessControl` with Apple access-control categories.
- Updated `AmenityCategory` snake_case values to Apple compact/dot values.
- Mapped curated `OccupantCategory` presets to Apple occupant category values.
- Expanded Domain tests for MVP category raw values.
- Updated schema gap documentation to reflect category alignment progress and remaining strategy questions.

## IMDF Impact

- Reduces `*CategoryMustBeValid` validator risk for unit, opening, amenity, occupant, and access-control values represented by the current MVP presets.
- Does not model the full Apple category catalog yet.
- Does not run Apple IMDF Sandbox; category values are aligned against Apple's local `categories_20210728.csv` asset.

## Architecture Notes

- Changes are scoped to Domain enum raw values and tests.
- Swift case names remain app-friendly where possible while raw values remain Apple IMDF values.
- Full category strategy remains open: enums vs raw strings vs curated presets.

## Verification

- [x] `Domain`: `mise exec -- tuist test Domain` succeeded with 15 tests.
- [x] `Data`: `mise exec -- tuist test Data` succeeded with 5 tests.
- [ ] `Presentation`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [ ] `DesignSystem`: Not run directly; compiled as part of `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` succeeded.
- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`: Not run; no Tuist manifest changes.
- [ ] Apple IMDF Validator / preflight: Apple IMDF Sandbox was not run.

## Screenshots Or Recording

Not applicable; no UI changes.

## Review Notes

- Check whether removing unsupported broad cases such as `other`, `corridor`, and old opening/access-control presets is acceptable before persisted project data exists.
- Check occupant mappings such as `retail -> shopping`, `office -> corporateoffices`, and `service -> localservices`.
- Check whether the docs correctly frame this as curated MVP preset alignment, not full Apple category catalog coverage.

## Related Issues

Closes #19

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
