### PR TITLE
feat: add anchor support for occupants

### DIFF
--- a/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
+++ b/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
@@ -24,6 +24,7 @@ private struct IMDFArchiveBuilder {
         files["footprint.geojson"] = try encode(collection(footprintFeatures()))
         files["level.geojson"] = try encode(collection(levelFeatures()))
         files["unit.geojson"] = try encode(collection(unitFeatures()))
+        files["anchor.geojson"] = try encode(collection(anchorFeatures()))
         files["opening.geojson"] = try encode(collection(openingFeatures()))
         files["amenity.geojson"] = try encode(collection(amenityFeatures()))
         files["occupant.geojson"] = try encode(collection(occupantFeatures()))
@@ -178,6 +179,27 @@ private struct IMDFArchiveBuilder {
         }
     }
 
+    private func anchorFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.units.flatMap { unit in
+                    unit.anchors.map { anchor in
+                        feature(
+                            id: anchor.id,
+                            featureType: "anchor",
+                            geometry: pointGeometry(anchor.coordinate),
+                            properties: compact([
+                                "unit_id": unit.id.uuidString,
+                                "level_id": level.id.uuidString,
+                                "building_id": building.id.uuidString
+                            ])
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     private func amenityFeatures() -> [[String: Any]] {
         venue.buildings.flatMap { building in
             building.levels.flatMap { level in
@@ -213,12 +235,10 @@ private struct IMDFArchiveBuilder {
                             properties: compact([
                                 "name": localized(occupant.name),
                                 "category": occupant.category?.rawValue,
+                                "anchor_id": occupant.anchorID?.uuidString,
                                 "phone": occupant.phone,
                                 "website": occupant.website?.absoluteString,
-                                "hours": occupant.hours,
-                                "unit_id": unit.id.uuidString,
-                                "level_id": level.id.uuidString,
-                                "building_id": building.id.uuidString
+                                "hours": occupant.hours
                             ])
                         )
                     }

--- a/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
+++ b/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
@@ -18,6 +18,7 @@ final class IMDFExporterTests: XCTestCase {
             Set(entries.keys),
             [
                 "address.geojson",
+                "anchor.geojson",
                 "amenity.geojson",
                 "building.geojson",
                 "footprint.geojson",
@@ -125,6 +126,37 @@ final class IMDFExporterTests: XCTestCase {
         XCTAssertNotNil(levelProperties["display_point"])
     }
 
+    func test_whenVenueWithOccupantAnchorIsExported_thenAnchorAndOccupantReferenceAreSerialized() async throws {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
+        let building = try XCTUnwrap(venue.buildings.first)
+        let level = try XCTUnwrap(building.levels.first)
+        let unit = try XCTUnwrap(level.units.first)
+        let anchor = try XCTUnwrap(unit.anchors.first)
+        let occupant = try XCTUnwrap(unit.occupants.first)
+
+        // When
+        let archive = try await sut.export(venue)
+        let entries = try ZipArchiveReader.entries(from: archive)
+        let anchorFeature = try singleFeature(in: "anchor.geojson", from: entries)
+        let anchorGeometry = try geometry(from: anchorFeature)
+        let anchorProperties = try XCTUnwrap(anchorFeature["properties"] as? [String: Any])
+        let occupantProperties = try properties(in: "occupant.geojson", from: entries)
+
+        // Then
+        XCTAssertEqual(anchorFeature["id"] as? String, anchor.id.uuidString)
+        XCTAssertEqual(anchorFeature["feature_type"] as? String, "anchor")
+        XCTAssertEqual(anchorGeometry["type"] as? String, "Point")
+        XCTAssertEqual(try pointCoordinates(from: anchorGeometry), [-122.03100, 37.33180])
+        XCTAssertEqual(anchorProperties["unit_id"] as? String, unit.id.uuidString)
+        XCTAssertEqual(anchorProperties["level_id"] as? String, level.id.uuidString)
+        XCTAssertEqual(anchorProperties["building_id"] as? String, building.id.uuidString)
+        XCTAssertEqual(occupantProperties["anchor_id"] as? String, anchor.id.uuidString)
+        XCTAssertEqual(occupantProperties["category"] as? String, occupant.category?.rawValue)
+        XCTAssertNil(occupantProperties["unit_id"])
+    }
+
     private func makeSUT() -> IMDFExporter {
         IMDFExporter()
     }
@@ -148,10 +180,18 @@ final class IMDFExporterTests: XCTestCase {
             Coordinate(latitude: 37.33210, longitude: -122.03070),
             Coordinate(latitude: 37.33210, longitude: -122.03130)
         ]
-        let unit = Unit(
+        let anchor = Anchor(coordinate: Coordinate(latitude: 37.33180, longitude: -122.03100))
+        let occupant = Occupant(
+            name: "Tenant",
+            category: .retail,
+            anchorID: anchor.id
+        )
+        let unit = Domain.Unit(
             name: "Lobby",
             category: .lobby,
-            coordinates: unitCoordinates
+            coordinates: unitCoordinates,
+            anchors: [anchor],
+            occupants: [occupant]
         )
         let level = Level(
             name: "Level 1",
@@ -218,6 +258,10 @@ final class IMDFExporterTests: XCTestCase {
 
     private func polygonCoordinates(from geometry: [String: Any]) throws -> [[[Double]]] {
         try XCTUnwrap(geometry["coordinates"] as? [[[Double]]])
+    }
+
+    private func pointCoordinates(from geometry: [String: Any]) throws -> [Double] {
+        try XCTUnwrap(geometry["coordinates"] as? [Double])
     }
 }
 

--- a/IMDFlex/Projects/Domain/Sources/Entities/Anchor.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Anchor.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// IMDF Anchor - occupant, fixture, kiosk 등이 참조하는 위치 기준점
+public struct Anchor: Identifiable, Codable, Sendable {
+    public let id: UUID
+    public var coordinate: Coordinate
+
+    public init(id: UUID = UUID(), coordinate: Coordinate) {
+        self.id = id
+        self.coordinate = coordinate
+    }
+}

--- a/IMDFlex/Projects/Domain/Sources/Entities/Occupant.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Occupant.swift
@@ -5,6 +5,7 @@ public struct Occupant: Identifiable, Codable, Sendable {
     public let id: UUID
     public var name: String
     public var category: OccupantCategory?
+    public var anchorID: UUID?
     public var phone: String?
     public var website: URL?
     public var hours: String?
@@ -13,6 +14,7 @@ public struct Occupant: Identifiable, Codable, Sendable {
         id: UUID = UUID(),
         name: String,
         category: OccupantCategory? = nil,
+        anchorID: UUID? = nil,
         phone: String? = nil,
         website: URL? = nil,
         hours: String? = nil
@@ -20,6 +22,7 @@ public struct Occupant: Identifiable, Codable, Sendable {
         self.id = id
         self.name = name
         self.category = category
+        self.anchorID = anchorID
         self.phone = phone
         self.website = website
         self.hours = hours

--- a/IMDFlex/Projects/Domain/Sources/Entities/Unit.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Unit.swift
@@ -6,6 +6,7 @@ public struct Unit: Identifiable, Codable, Sendable {
     public var name: String?
     public var category: UnitCategory
     public var coordinates: [Coordinate]
+    public var anchors: [Anchor]
     public var amenities: [Amenity]
     public var occupants: [Occupant]
     
@@ -14,6 +15,7 @@ public struct Unit: Identifiable, Codable, Sendable {
         name: String? = nil,
         category: UnitCategory,
         coordinates: [Coordinate] = [],
+        anchors: [Anchor] = [],
         amenities: [Amenity] = [],
         occupants: [Occupant] = []
     ) {
@@ -21,6 +23,7 @@ public struct Unit: Identifiable, Codable, Sendable {
         self.name = name
         self.category = category
         self.coordinates = coordinates
+        self.anchors = anchors
         self.amenities = amenities
         self.occupants = occupants
     }

--- a/IMDFlex/Projects/Domain/Sources/UseCases/IMDFPreflightValidator.swift
+++ b/IMDFlex/Projects/Domain/Sources/UseCases/IMDFPreflightValidator.swift
@@ -149,12 +149,16 @@ public struct IMDFPreflightValidator: IMDFPreflightValidating, Sendable {
             }
 
             for occupant in unit.occupants {
-                validateOccupant(occupant, issues: &issues)
+                validateOccupant(occupant, anchors: unit.anchors, issues: &issues)
             }
         }
     }
 
-    private func validateOccupant(_ occupant: Occupant, issues: inout [IMDFPreflightIssue]) {
+    private func validateOccupant(
+        _ occupant: Occupant,
+        anchors: [Anchor],
+        issues: inout [IMDFPreflightIssue]
+    ) {
         if occupant.category == nil {
             issues.append(
                 .init(
@@ -167,15 +171,30 @@ public struct IMDFPreflightValidator: IMDFPreflightValidating, Sendable {
             )
         }
 
-        issues.append(
-            .init(
-                code: .occupantAnchorUnsupported,
-                severity: .error,
-                feature: .occupant,
-                featureID: occupant.id,
-                message: "Occupant export requires anchor support, which is not implemented yet."
+        guard let anchorID = occupant.anchorID else {
+            issues.append(
+                .init(
+                    code: .occupantMissingAnchor,
+                    severity: .error,
+                    feature: .occupant,
+                    featureID: occupant.id,
+                    message: "Occupant must reference an anchor."
+                )
             )
-        )
+            return
+        }
+
+        if !anchors.contains(where: { $0.id == anchorID }) {
+            issues.append(
+                .init(
+                    code: .occupantAnchorNotFound,
+                    severity: .error,
+                    feature: .anchor,
+                    featureID: anchorID,
+                    message: "Occupant anchor reference must resolve to an anchor in the same unit."
+                )
+            )
+        }
     }
 
     private func isValidPolygon(_ coordinates: [Coordinate]) -> Bool {
@@ -232,7 +251,8 @@ public enum IMDFPreflightIssueCode: String, Codable, CaseIterable, Sendable {
     case levelMissingUnit
     case unitInvalidPolygon
     case occupantMissingCategory
-    case occupantAnchorUnsupported
+    case occupantMissingAnchor
+    case occupantAnchorNotFound
 }
 
 public enum IMDFPreflightSeverity: String, Codable, CaseIterable, Sendable {
@@ -246,5 +266,6 @@ public enum IMDFPreflightFeature: String, Codable, CaseIterable, Sendable {
     case footprint
     case level
     case unit
+    case anchor
     case occupant
 }

--- a/IMDFlex/Projects/Domain/Tests/IMDFPreflightValidatorTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/IMDFPreflightValidatorTests.swift
@@ -118,9 +118,41 @@ final class IMDFPreflightValidatorTests: XCTestCase {
         let issues = sut.validate(venue)
 
         // Then
-        XCTAssertEqual(issueCodes(in: issues), [.unitInvalidPolygon, .occupantMissingCategory, .occupantAnchorUnsupported])
+        XCTAssertEqual(issueCodes(in: issues), [.unitInvalidPolygon, .occupantMissingCategory, .occupantMissingAnchor])
         XCTAssertEqual(issues.map(\.feature), [.unit, .occupant, .occupant])
         XCTAssertTrue(issues.contains { $0.featureID == occupant.id })
+    }
+
+    func test_whenOccupantReferencesAnchorInSameUnit_thenValidatorReturnsNoOccupantAnchorIssue() {
+        // Given
+        let sut = makeSUT()
+        let anchor = Anchor(coordinate: Coordinate(latitude: 37.33180, longitude: -122.03100))
+        let occupant = Occupant(name: "Tenant", category: .retail, anchorID: anchor.id)
+        let unit = makeUnitFixture(anchors: [anchor], occupants: [occupant])
+        let venue = makeVenueFixture(buildings: [makeBuildingFixture(units: [unit])])
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertFalse(issues.contains { $0.featureID == occupant.id })
+    }
+
+    func test_whenOccupantReferencesUnknownAnchor_thenValidatorReturnsAnchorReferenceIssue() {
+        // Given
+        let sut = makeSUT()
+        let anchorID = UUID()
+        let occupant = Occupant(name: "Tenant", category: .retail, anchorID: anchorID)
+        let unit = makeUnitFixture(occupants: [occupant])
+        let venue = makeVenueFixture(buildings: [makeBuildingFixture(units: [unit])])
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertEqual(issueCodes(in: issues), [.occupantAnchorNotFound])
+        XCTAssertEqual(issues.first?.feature, .anchor)
+        XCTAssertEqual(issues.first?.featureID, anchorID)
     }
 
     func test_whenIssueIsCreated_thenIDIncludesCodeFeatureAndFeatureID() throws {
@@ -161,7 +193,7 @@ final class IMDFPreflightValidatorTests: XCTestCase {
         )
     }
 
-    private func makeBuildingFixture() -> Building {
+    private func makeBuildingFixture(units: [Domain.Unit]? = nil) -> Building {
         Building(
             name: "Main",
             levels: [
@@ -170,7 +202,7 @@ final class IMDFPreflightValidatorTests: XCTestCase {
                     ordinal: 0,
                     shortName: "1F",
                     coordinates: squareCoordinates(),
-                    units: [makeUnitFixture()]
+                    units: units ?? [makeUnitFixture()]
                 )
             ],
             footprint: makeFootprintFixture()
@@ -181,8 +213,17 @@ final class IMDFPreflightValidatorTests: XCTestCase {
         Footprint(coordinates: squareCoordinates())
     }
 
-    private func makeUnitFixture() -> Domain.Unit {
-        Domain.Unit(name: "Lobby", category: .lobby, coordinates: squareCoordinates())
+    private func makeUnitFixture(
+        anchors: [Anchor] = [],
+        occupants: [Occupant] = []
+    ) -> Domain.Unit {
+        Domain.Unit(
+            name: "Lobby",
+            category: .lobby,
+            coordinates: squareCoordinates(),
+            anchors: anchors,
+            occupants: occupants
+        )
     }
 
     private func squareCoordinates() -> [Coordinate] {

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -110,13 +110,13 @@ Apple validation includes:
 - `OccupantMustHaveCategory`
 - `OccupantMustHaveName`
 
-Current MVP scope includes `occupant` but not `anchor`. Current `Occupant` has no anchor reference, and current exporter writes `unit_id` instead.
+Current MVP scope includes `occupant` and now includes local `anchor` support. `Occupant` stores an optional `anchorID`, `Unit` owns anchors, and the exporter writes `anchor.geojson` plus `occupant.properties.anchor_id`.
 
-Required direction:
+Remaining direction:
 
-- Decide whether MVP includes `anchor`.
-- If `occupant` remains in MVP, add `Anchor` Domain model and `anchor.geojson` export.
-- If `anchor` is deferred, defer `occupant` from Apple-submission MVP export.
+- Confirm exported `anchor` and `occupant` relationships with Apple IMDF Sandbox.
+- Add topology checks for anchor coverage by the referenced unit.
+- Decide whether anchors can later be reused by fixtures, kiosks, or other IMDF features.
 
 ## Feature-Level Gap Table
 
@@ -131,8 +131,8 @@ Required direction:
 | Unit | Model exists | Category values need Apple alignment; level containment needs preflight | P1 |
 | Opening | Model exists | Category/access-control values need Apple alignment | P1 |
 | Amenity | Model exists | Coordinate optional but point geometry required; category values incomplete | P1 |
-| Occupant | Model exists | Requires anchor reference; category values incomplete | P0 decision |
-| Anchor | Not in MVP model | Required if exporting occupants | P0 decision |
+| Occupant | Model exists with anchor reference | Category values incomplete; Sandbox confirmation pending | P1 |
+| Anchor | Model and export exist locally | Coverage by referenced unit not yet checked locally | P1 |
 
 ## Apple Category Baseline For MVP
 
@@ -168,7 +168,7 @@ Use Apple category values as raw export values.
 2. Add explicit geometry/category fields for `Venue`, `Building`, `Footprint`, and `Level`. Done locally; Apple Sandbox confirmation pending.
 3. Align remaining MVP category enums with Apple category CSV raw values. Curated MVP presets are aligned locally; full category strategy remains open.
 4. Add a preflight validator for required relationships and required geometry. Started locally with model-level required data checks.
-5. Decide `Occupant + Anchor` scope before exporting occupants as Apple-submission data.
+5. Add `Occupant + Anchor` relationship support before exporting occupants as Apple-submission data. Done locally; Apple Sandbox confirmation pending.
 6. Add module tests:
    - `Domain`: entity construction and category raw values.
    - `Data`: exported ZIP file list and GeoJSON structure.
@@ -191,7 +191,8 @@ The first local preflight pass checks model-level issues that can be detected wi
 - Level has at least one unit.
 - Unit has enough coordinates to form a polygon.
 - Occupant has a category.
-- Occupant export is blocked until anchor support exists.
+- Occupant references an anchor.
+- Occupant anchor reference resolves to an anchor in the same unit.
 
 The preflight validator intentionally does not yet prove:
 
@@ -204,5 +205,5 @@ The preflight validator intentionally does not yet prove:
 
 - Should `Venue` polygon be drawn directly by the user, derived from building footprints, or both?
 - Should `Level` polygon be copied from the building footprint by default?
-- Should `Occupant` be deferred until `Anchor` is implemented?
+- Should anchors be shared only inside a unit, or should future editor tools surface a broader anchor management concept?
 - Should full Apple category lists be modeled as enums, or should the app store raw category strings plus curated presets?


### PR DESCRIPTION
## Summary

Adds local IMDF anchor support so exported occupants can reference `anchor_id` instead of unit/level/building properties.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added a Domain `Anchor` entity and let `Unit` own anchors.
- Added optional `Occupant.anchorID` and exported `anchor.geojson`.
- Updated occupant export to serialize `anchor_id`.
- Updated local preflight to report missing or unresolved occupant anchors.
- Added GWT-style Domain/Data tests for anchor references and exporter output.
- Updated `docs/imdf-schema-gap.md` with the new local anchor status.

## IMDF Impact

- Adds `anchor.geojson` to `imdf.zip`.
- Occupants now export `anchor_id`, matching Apple validation direction for `OccupantMustReferenceAnchor`.
- Local preflight now checks occupant category, anchor presence, and anchor resolution in the same unit.
- Apple IMDF Sandbox / Validator acceptance is still pending and is not claimed by this PR.

## Architecture Notes

- Domain remains independent of Data and UI concerns.
- Data consumes public Domain models only.
- Preflight remains a model-level authoring aid, not a replacement for Apple IMDF Validator.

## Verification

- [x] `Domain`: `mise exec -- tuist test Domain` passed, 17 tests.
- [x] `Data`: `mise exec -- tuist test Data` passed, 6 tests.
- [x] `Presentation`: compiled through `mise exec -- tuist build IMDFlex`.
- [x] `DesignSystem`: included through cached build graph in `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`: not run; no Tuist manifest change.
- [ ] Apple IMDF Validator / preflight: Apple Sandbox/Validator not run locally; local preflight tests passed.

## Screenshots Or Recording

Not applicable; no UI changes.

## Related Issues

Closes #21

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
