### PR TITLE
feat: expand MVP to all IMDF features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ IMDFlex is an Apple IMDF authoring app for iPad and Mac. It should help users cr
   7. Export `imdf.zip`.
   8. Run preflight checks and guide Apple IMDF Validator verification.
 - Floor-plan overlays should support moving, scaling, rotating, opacity adjustment, and alignment against the building outline.
-- The MVP IMDF feature scope is:
+- The MVP IMDF feature scope includes every Apple IMDF feature collection, with simple manual authoring depth first:
   - `address`
   - `venue`
   - `building`
@@ -31,7 +31,14 @@ IMDFlex is an Apple IMDF authoring app for iPad and Mac. It should help users cr
   - `unit`
   - `opening`
   - `amenity`
+  - `anchor`
   - `occupant`
+  - `detail`
+  - `fixture`
+  - `geofence`
+  - `kiosk`
+  - `relationship`
+  - `section`
 
 ## Technology
 

--- a/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
+++ b/IMDFlex/Projects/Data/Sources/DataSources/IMDFExporter.swift
@@ -28,6 +28,12 @@ private struct IMDFArchiveBuilder {
         files["opening.geojson"] = try encode(collection(openingFeatures()))
         files["amenity.geojson"] = try encode(collection(amenityFeatures()))
         files["occupant.geojson"] = try encode(collection(occupantFeatures()))
+        files["detail.geojson"] = try encode(collection(detailFeatures()))
+        files["fixture.geojson"] = try encode(collection(fixtureFeatures()))
+        files["geofence.geojson"] = try encode(collection(geofenceFeatures()))
+        files["kiosk.geojson"] = try encode(collection(kioskFeatures()))
+        files["relationship.geojson"] = try encode(collection(relationshipFeatures()))
+        files["section.geojson"] = try encode(collection(sectionFeatures()))
 
         return files
     }
@@ -247,6 +253,126 @@ private struct IMDFArchiveBuilder {
         }
     }
 
+    private func detailFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.details.map { detail in
+                    feature(
+                        id: detail.id,
+                        featureType: "detail",
+                        geometry: lineGeometry(detail.coordinates),
+                        properties: compact([
+                            "name": localized(detail.name),
+                            "level_id": level.id.uuidString,
+                            "building_id": building.id.uuidString
+                        ])
+                    )
+                }
+            }
+        }
+    }
+
+    private func fixtureFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.fixtures.map { fixture in
+                    feature(
+                        id: fixture.id,
+                        featureType: "fixture",
+                        geometry: polygonGeometry(fixture.coordinates),
+                        properties: compact([
+                            "category": fixture.category.rawValue,
+                            "name": localized(fixture.name),
+                            "level_id": level.id.uuidString,
+                            "building_id": building.id.uuidString,
+                            "anchor_ids": uuidStrings(fixture.anchorIDs),
+                            "display_point": displayPoint(for: fixture.coordinates)
+                        ])
+                    )
+                }
+            }
+        }
+    }
+
+    private func geofenceFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.geofences.map { geofence in
+                    feature(
+                        id: geofence.id,
+                        featureType: "geofence",
+                        geometry: polygonGeometry(geofence.coordinates),
+                        properties: compact([
+                            "category": geofence.category.rawValue,
+                            "name": localized(geofence.name),
+                            "level_id": level.id.uuidString,
+                            "building_id": building.id.uuidString,
+                            "display_point": displayPoint(for: geofence.coordinates)
+                        ])
+                    )
+                }
+            }
+        }
+    }
+
+    private func kioskFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.kiosks.map { kiosk in
+                    feature(
+                        id: kiosk.id,
+                        featureType: "kiosk",
+                        geometry: polygonGeometry(kiosk.coordinates),
+                        properties: compact([
+                            "name": localized(kiosk.name),
+                            "level_id": level.id.uuidString,
+                            "building_id": building.id.uuidString,
+                            "anchor_ids": uuidStrings(kiosk.anchorIDs),
+                            "display_point": displayPoint(for: kiosk.coordinates)
+                        ])
+                    )
+                }
+            }
+        }
+    }
+
+    private func relationshipFeatures() -> [[String: Any]] {
+        venue.relationships.map { relationship in
+            feature(
+                id: relationship.id,
+                featureType: "relationship",
+                geometry: NSNull(),
+                properties: compact([
+                    "category": relationship.category.rawValue,
+                    "direction": relationship.direction?.rawValue,
+                    "origin_id": relationship.originID.uuidString,
+                    "destination_id": relationship.destinationID.uuidString
+                ])
+            )
+        }
+    }
+
+    private func sectionFeatures() -> [[String: Any]] {
+        venue.buildings.flatMap { building in
+            building.levels.flatMap { level in
+                level.sections.map { section in
+                    feature(
+                        id: section.id,
+                        featureType: "section",
+                        geometry: polygonGeometry(section.coordinates),
+                        properties: compact([
+                            "category": section.category.rawValue,
+                            "name": localized(section.name),
+                            "level_id": level.id.uuidString,
+                            "building_id": building.id.uuidString,
+                            "display_point": displayPoint(for: section.coordinates)
+                        ])
+                    )
+                }
+            }
+        }
+    }
+
     private func feature(
         id: UUID,
         featureType: String,
@@ -348,6 +474,11 @@ private struct IMDFArchiveBuilder {
     private func localized(_ value: String?) -> [String: String]? {
         guard let value, !value.isEmpty else { return nil }
         return ["ko": value]
+    }
+
+    private func uuidStrings(_ ids: [UUID]) -> [String]? {
+        guard !ids.isEmpty else { return nil }
+        return ids.map(\.uuidString)
     }
 
     private func compact(_ values: [String: Any?]) -> [String: Any] {

--- a/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
+++ b/IMDFlex/Projects/Data/Tests/IMDFExporterTests.swift
@@ -21,11 +21,17 @@ final class IMDFExporterTests: XCTestCase {
                 "anchor.geojson",
                 "amenity.geojson",
                 "building.geojson",
+                "detail.geojson",
+                "fixture.geojson",
                 "footprint.geojson",
+                "geofence.geojson",
+                "kiosk.geojson",
                 "level.geojson",
                 "manifest.json",
                 "occupant.geojson",
                 "opening.geojson",
+                "relationship.geojson",
+                "section.geojson",
                 "unit.geojson",
                 "venue.geojson"
             ]
@@ -157,6 +163,57 @@ final class IMDFExporterTests: XCTestCase {
         XCTAssertNil(occupantProperties["unit_id"])
     }
 
+    func test_whenAllIMDFFeaturesAreExported_thenNewFeatureCollectionsUseExpectedGeometryAndReferences() async throws {
+        // Given
+        let sut = makeSUT()
+        let venue = makeVenueFixture()
+        let building = try XCTUnwrap(venue.buildings.first)
+        let level = try XCTUnwrap(building.levels.first)
+        let detail = try XCTUnwrap(level.details.first)
+        let fixture = try XCTUnwrap(level.fixtures.first)
+        let geofence = try XCTUnwrap(level.geofences.first)
+        let kiosk = try XCTUnwrap(level.kiosks.first)
+        let section = try XCTUnwrap(level.sections.first)
+        let relationship = try XCTUnwrap(venue.relationships.first)
+
+        // When
+        let archive = try await sut.export(venue)
+        let entries = try ZipArchiveReader.entries(from: archive)
+        let detailGeometry = try geometry(in: "detail.geojson", from: entries)
+        let fixtureFeature = try singleFeature(in: "fixture.geojson", from: entries)
+        let fixtureGeometry = try geometry(from: fixtureFeature)
+        let fixtureProperties = try XCTUnwrap(fixtureFeature["properties"] as? [String: Any])
+        let geofenceProperties = try properties(in: "geofence.geojson", from: entries)
+        let kioskFeature = try singleFeature(in: "kiosk.geojson", from: entries)
+        let kioskGeometry = try geometry(in: "kiosk.geojson", from: entries)
+        let kioskProperties = try XCTUnwrap(kioskFeature["properties"] as? [String: Any])
+        let relationshipFeature = try singleFeature(in: "relationship.geojson", from: entries)
+        let relationshipProperties = try XCTUnwrap(relationshipFeature["properties"] as? [String: Any])
+        let sectionProperties = try properties(in: "section.geojson", from: entries)
+
+        // Then
+        XCTAssertEqual(detailGeometry["type"] as? String, "LineString")
+        XCTAssertEqual(try lineCoordinates(from: detailGeometry).first, [-122.03105, 37.33175])
+        XCTAssertEqual(detail.id.uuidString, try singleFeature(in: "detail.geojson", from: entries)["id"] as? String)
+
+        XCTAssertEqual(fixtureFeature["id"] as? String, fixture.id.uuidString)
+        XCTAssertEqual(fixtureGeometry["type"] as? String, "Polygon")
+        XCTAssertEqual(fixtureProperties["category"] as? String, fixture.category.rawValue)
+        XCTAssertEqual(fixtureProperties["level_id"] as? String, level.id.uuidString)
+        XCTAssertEqual(fixtureProperties["building_id"] as? String, building.id.uuidString)
+
+        XCTAssertEqual(geofenceProperties["category"] as? String, geofence.category.rawValue)
+        XCTAssertEqual(kioskFeature["id"] as? String, kiosk.id.uuidString)
+        XCTAssertEqual(kioskGeometry["type"] as? String, "Polygon")
+        XCTAssertEqual(kioskProperties["level_id"] as? String, level.id.uuidString)
+        XCTAssertEqual(relationshipFeature["id"] as? String, relationship.id.uuidString)
+        XCTAssertTrue(relationshipFeature["geometry"] is NSNull)
+        XCTAssertEqual(relationshipProperties["category"] as? String, relationship.category.rawValue)
+        XCTAssertEqual(relationshipProperties["origin_id"] as? String, relationship.originID.uuidString)
+        XCTAssertEqual(relationshipProperties["destination_id"] as? String, relationship.destinationID.uuidString)
+        XCTAssertEqual(sectionProperties["category"] as? String, section.category.rawValue)
+    }
+
     private func makeSUT() -> IMDFExporter {
         IMDFExporter()
     }
@@ -193,13 +250,44 @@ final class IMDFExporterTests: XCTestCase {
             anchors: [anchor],
             occupants: [occupant]
         )
+        let detail = Detail(
+            name: "Wall Detail",
+            coordinates: [
+                Coordinate(latitude: 37.33175, longitude: -122.03105),
+                Coordinate(latitude: 37.33185, longitude: -122.03100)
+            ]
+        )
+        let fixture = Fixture(
+            name: "Desk",
+            category: .desk,
+            coordinates: unitCoordinates
+        )
+        let geofence = Geofence(
+            name: "Paid Area",
+            category: .paidArea,
+            coordinates: footprintCoordinates
+        )
+        let kiosk = Kiosk(
+            name: "Info Kiosk",
+            coordinates: unitCoordinates
+        )
+        let section = Section(
+            name: "Gate Area",
+            category: .gateArea,
+            coordinates: footprintCoordinates
+        )
         let level = Level(
             name: "Level 1",
             category: .unspecified,
             ordinal: 0,
             shortName: "1F",
             coordinates: footprintCoordinates,
-            units: [unit]
+            units: [unit],
+            details: [detail],
+            fixtures: [fixture],
+            geofences: [geofence],
+            kiosks: [kiosk],
+            sections: [section]
         )
         let footprint = Footprint(
             category: .ground,
@@ -224,7 +312,14 @@ final class IMDFExporterTests: XCTestCase {
             category: .shoppingCenter,
             coordinates: venueCoordinates,
             buildings: [building],
-            address: address
+            address: address,
+            relationships: [
+                Relationship(
+                    category: .traversal,
+                    originID: unit.id,
+                    destinationID: section.id
+                )
+            ]
         )
     }
 
@@ -262,6 +357,10 @@ final class IMDFExporterTests: XCTestCase {
 
     private func pointCoordinates(from geometry: [String: Any]) throws -> [Double] {
         try XCTUnwrap(geometry["coordinates"] as? [Double])
+    }
+
+    private func lineCoordinates(from geometry: [String: Any]) throws -> [[Double]] {
+        try XCTUnwrap(geometry["coordinates"] as? [[Double]])
     }
 }
 

--- a/IMDFlex/Projects/Domain/Sources/Entities/Detail.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Detail.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// IMDF Detail - level에 속한 선형 세부 요소
+public struct Detail: Identifiable, Codable, Sendable {
+    public let id: UUID
+    public var name: String?
+    public var coordinates: [Coordinate]
+
+    public init(
+        id: UUID = UUID(),
+        name: String? = nil,
+        coordinates: [Coordinate] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.coordinates = coordinates
+    }
+}

--- a/IMDFlex/Projects/Domain/Sources/Entities/Fixture.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Fixture.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// IMDF Fixture - level에 배치되는 고정 구조물 또는 가구
+public struct Fixture: Identifiable, Codable, Sendable {
+    public let id: UUID
+    public var name: String?
+    public var category: FixtureCategory
+    public var coordinates: [Coordinate]
+    public var anchorIDs: [UUID]
+
+    public init(
+        id: UUID = UUID(),
+        name: String? = nil,
+        category: FixtureCategory = .furniture,
+        coordinates: [Coordinate] = [],
+        anchorIDs: [UUID] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.category = category
+        self.coordinates = coordinates
+        self.anchorIDs = anchorIDs
+    }
+}
+
+public enum FixtureCategory: String, Codable, CaseIterable, Sendable {
+    case baggageCarousel = "baggagecarousel"
+    case boardingGateDesk = "boardinggate.desk"
+    case checkInDesk = "checkin.desk"
+    case checkInKiosk = "checkin.kiosk"
+    case desk
+    case equipment
+    case furniture
+    case immigrationDesk = "immigration.desk"
+    case inspectionDesk = "inspection.desk"
+    case obstruction
+    case securityEquipment = "securityequipment"
+    case stage
+    case vegetation
+    case wall
+    case water
+}

--- a/IMDFlex/Projects/Domain/Sources/Entities/Geofence.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Geofence.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// IMDF Geofence - level 또는 building에 적용되는 제한/구역 경계
+public struct Geofence: Identifiable, Codable, Sendable {
+    public let id: UUID
+    public var name: String?
+    public var category: GeofenceCategory
+    public var coordinates: [Coordinate]
+
+    public init(
+        id: UUID = UUID(),
+        name: String? = nil,
+        category: GeofenceCategory = .geofence,
+        coordinates: [Coordinate] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.category = category
+        self.coordinates = coordinates
+    }
+}
+
+public enum GeofenceCategory: String, Codable, CaseIterable, Sendable {
+    case concourse
+    case geofence
+    case paidArea = "paidarea"
+    case platform
+    case postSecurity = "postsecurity"
+    case preSecurity = "presecurity"
+    case terminal
+    case underConstruction = "underconstruction"
+}

--- a/IMDFlex/Projects/Domain/Sources/Entities/Kiosk.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Kiosk.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// IMDF Kiosk - level에 배치되는 키오스크 영역
+public struct Kiosk: Identifiable, Codable, Sendable {
+    public let id: UUID
+    public var name: String?
+    public var coordinates: [Coordinate]
+    public var anchorIDs: [UUID]
+
+    public init(
+        id: UUID = UUID(),
+        name: String? = nil,
+        coordinates: [Coordinate] = [],
+        anchorIDs: [UUID] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.coordinates = coordinates
+        self.anchorIDs = anchorIDs
+    }
+}

--- a/IMDFlex/Projects/Domain/Sources/Entities/Level.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Level.swift
@@ -10,6 +10,11 @@ public struct Level: Identifiable, Codable, Sendable {
     public var coordinates: [Coordinate]
     public var units: [Unit]
     public var openings: [Opening]
+    public var details: [Detail]
+    public var fixtures: [Fixture]
+    public var geofences: [Geofence]
+    public var kiosks: [Kiosk]
+    public var sections: [Section]
     
     public init(
         id: UUID = UUID(),
@@ -19,7 +24,12 @@ public struct Level: Identifiable, Codable, Sendable {
         shortName: String? = nil,
         coordinates: [Coordinate] = [],
         units: [Unit] = [],
-        openings: [Opening] = []
+        openings: [Opening] = [],
+        details: [Detail] = [],
+        fixtures: [Fixture] = [],
+        geofences: [Geofence] = [],
+        kiosks: [Kiosk] = [],
+        sections: [Section] = []
     ) {
         self.id = id
         self.name = name
@@ -29,6 +39,11 @@ public struct Level: Identifiable, Codable, Sendable {
         self.coordinates = coordinates
         self.units = units
         self.openings = openings
+        self.details = details
+        self.fixtures = fixtures
+        self.geofences = geofences
+        self.kiosks = kiosks
+        self.sections = sections
     }
 }
 

--- a/IMDFlex/Projects/Domain/Sources/Entities/Relationship.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Relationship.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// IMDF Relationship - 이동/연결 관계
+public struct Relationship: Identifiable, Codable, Sendable {
+    public let id: UUID
+    public var category: RelationshipCategory
+    public var direction: RelationshipDirection?
+    public var originID: UUID
+    public var destinationID: UUID
+
+    public init(
+        id: UUID = UUID(),
+        category: RelationshipCategory,
+        direction: RelationshipDirection? = nil,
+        originID: UUID,
+        destinationID: UUID
+    ) {
+        self.id = id
+        self.category = category
+        self.direction = direction
+        self.originID = originID
+        self.destinationID = destinationID
+    }
+}
+
+public enum RelationshipCategory: String, Codable, CaseIterable, Sendable {
+    case elevator
+    case escalator
+    case movingWalkway = "movingwalkway"
+    case ramp
+    case stairs
+    case traversal
+    case traversalPath = "traversal.path"
+}
+
+public enum RelationshipDirection: String, Codable, CaseIterable, Sendable {
+    case bidirectional
+    case unidirectional
+}

--- a/IMDFlex/Projects/Domain/Sources/Entities/Section.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Section.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+/// IMDF Section - level 안의 의미 있는 구역
+public struct Section: Identifiable, Codable, Sendable {
+    public let id: UUID
+    public var name: String?
+    public var category: SectionCategory
+    public var coordinates: [Coordinate]
+
+    public init(
+        id: UUID = UUID(),
+        name: String? = nil,
+        category: SectionCategory = .walkway,
+        coordinates: [Coordinate] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.category = category
+        self.coordinates = coordinates
+    }
+}
+
+public enum SectionCategory: String, Codable, CaseIterable, Sendable {
+    case arcade
+    case baggageClaim = "baggageclaim"
+    case checkIn = "checkin"
+    case concessions
+    case eatingDrinking = "eatingdrinking"
+    case entertainmentArea = "entertainmentarea"
+    case exhibit
+    case gateArea = "gatearea"
+    case information
+    case paidArea = "paidarea"
+    case parking
+    case platform
+    case postSecurity = "postsecurity"
+    case preSecurity = "presecurity"
+    case privateArea = "private"
+    case recreation
+    case retail
+    case road
+    case seating
+    case security
+    case serviceArea = "servicearea"
+    case ticketing
+    case vegetation
+    case walkway
+}

--- a/IMDFlex/Projects/Domain/Sources/Entities/Venue.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/Venue.swift
@@ -8,6 +8,7 @@ public struct Venue: Identifiable, Codable, Sendable {
     public var coordinates: [Coordinate]
     public var buildings: [Building]
     public var address: Address?
+    public var relationships: [Relationship]
     
     public init(
         id: UUID = UUID(),
@@ -15,7 +16,8 @@ public struct Venue: Identifiable, Codable, Sendable {
         category: VenueCategory,
         coordinates: [Coordinate] = [],
         buildings: [Building] = [],
-        address: Address? = nil
+        address: Address? = nil,
+        relationships: [Relationship] = []
     ) {
         self.id = id
         self.name = name
@@ -23,6 +25,7 @@ public struct Venue: Identifiable, Codable, Sendable {
         self.coordinates = coordinates
         self.buildings = buildings
         self.address = address
+        self.relationships = relationships
     }
 }
 

--- a/IMDFlex/Projects/Domain/Sources/UseCases/IMDFPreflightValidator.swift
+++ b/IMDFlex/Projects/Domain/Sources/UseCases/IMDFPreflightValidator.swift
@@ -9,8 +9,10 @@ public struct IMDFPreflightValidator: IMDFPreflightValidating, Sendable {
 
     public func validate(_ venue: Venue) -> [IMDFPreflightIssue] {
         var issues: [IMDFPreflightIssue] = []
+        let featureIDs = collectFeatureIDs(in: venue)
 
         validateVenue(venue, issues: &issues)
+        validateRelationships(venue.relationships, featureIDs: featureIDs, issues: &issues)
 
         for building in venue.buildings {
             validateBuilding(building, issues: &issues)
@@ -18,6 +20,7 @@ public struct IMDFPreflightValidator: IMDFPreflightValidating, Sendable {
             for level in building.levels {
                 validateLevel(level, building: building, issues: &issues)
                 validateUnits(in: level, issues: &issues)
+                validateLevelFeatureCollections(in: level, issues: &issues)
             }
         }
 
@@ -154,6 +157,100 @@ public struct IMDFPreflightValidator: IMDFPreflightValidating, Sendable {
         }
     }
 
+    private func validateLevelFeatureCollections(in level: Level, issues: inout [IMDFPreflightIssue]) {
+        for detail in level.details where !isValidLine(detail.coordinates) {
+            issues.append(
+                .init(
+                    code: .detailInvalidLine,
+                    severity: .error,
+                    feature: .detail,
+                    featureID: detail.id,
+                    message: "Detail must have at least two line coordinates."
+                )
+            )
+        }
+
+        for fixture in level.fixtures where !isValidPolygon(fixture.coordinates) {
+            issues.append(
+                .init(
+                    code: .fixtureInvalidPolygon,
+                    severity: .error,
+                    feature: .fixture,
+                    featureID: fixture.id,
+                    message: "Fixture must have at least three polygon coordinates."
+                )
+            )
+        }
+
+        for geofence in level.geofences where !isValidPolygon(geofence.coordinates) {
+            issues.append(
+                .init(
+                    code: .geofenceInvalidPolygon,
+                    severity: .error,
+                    feature: .geofence,
+                    featureID: geofence.id,
+                    message: "Geofence must have at least three polygon coordinates."
+                )
+            )
+        }
+
+        for kiosk in level.kiosks where !isValidPolygon(kiosk.coordinates) {
+            issues.append(
+                .init(
+                    code: .kioskInvalidPolygon,
+                    severity: .error,
+                    feature: .kiosk,
+                    featureID: kiosk.id,
+                    message: "Kiosk must have at least three polygon coordinates."
+                )
+            )
+        }
+
+        for section in level.sections where !isValidPolygon(section.coordinates) {
+            issues.append(
+                .init(
+                    code: .sectionInvalidPolygon,
+                    severity: .error,
+                    feature: .section,
+                    featureID: section.id,
+                    message: "Section must have at least three polygon coordinates."
+                )
+            )
+        }
+    }
+
+    private func validateRelationships(
+        _ relationships: [Relationship],
+        featureIDs: Set<UUID>,
+        issues: inout [IMDFPreflightIssue]
+    ) {
+        for relationship in relationships {
+            if relationship.originID == relationship.destinationID {
+                issues.append(
+                    .init(
+                        code: .relationshipSelfReference,
+                        severity: .error,
+                        feature: .relationship,
+                        featureID: relationship.id,
+                        message: "Relationship origin and destination must reference different features."
+                    )
+                )
+            }
+
+            if !featureIDs.contains(relationship.originID) || !featureIDs.contains(relationship.destinationID) {
+                issues.append(
+                    .init(
+                        code: .relationshipEndpointNotFound,
+                        severity: .error,
+                        feature: .relationship,
+                        featureID: relationship.id,
+                        message: "Relationship origin and destination references must resolve to authored features."
+                    )
+                )
+            }
+        }
+    }
+
     private func validateOccupant(
         _ occupant: Occupant,
         anchors: [Anchor],
@@ -201,12 +298,50 @@ public struct IMDFPreflightValidator: IMDFPreflightValidating, Sendable {
         uniqueCoordinates(in: coordinates).count >= 3
     }
 
+    private func isValidLine(_ coordinates: [Coordinate]) -> Bool {
+        uniqueCoordinates(in: coordinates).count >= 2
+    }
+
     private func uniqueCoordinates(in coordinates: [Coordinate]) -> [Coordinate] {
         coordinates.reduce(into: []) { result, coordinate in
             if !result.contains(coordinate) {
                 result.append(coordinate)
             }
         }
+    }
+
+    private func collectFeatureIDs(in venue: Venue) -> Set<UUID> {
+        var ids: Set<UUID> = [venue.id]
+
+        if let address = venue.address {
+            ids.insert(address.id)
+        }
+
+        for building in venue.buildings {
+            ids.insert(building.id)
+
+            if let footprint = building.footprint {
+                ids.insert(footprint.id)
+            }
+
+            for level in building.levels {
+                ids.insert(level.id)
+                ids.formUnion(level.units.flatMap { unit in
+                    [unit.id]
+                        + unit.anchors.map(\.id)
+                        + unit.amenities.map(\.id)
+                        + unit.occupants.map(\.id)
+                })
+                ids.formUnion(level.openings.map(\.id))
+                ids.formUnion(level.details.map(\.id))
+                ids.formUnion(level.fixtures.map(\.id))
+                ids.formUnion(level.geofences.map(\.id))
+                ids.formUnion(level.kiosks.map(\.id))
+                ids.formUnion(level.sections.map(\.id))
+            }
+        }
+
+        return ids
     }
 }
 
@@ -253,6 +388,13 @@ public enum IMDFPreflightIssueCode: String, Codable, CaseIterable, Sendable {
     case occupantMissingCategory
     case occupantMissingAnchor
     case occupantAnchorNotFound
+    case detailInvalidLine
+    case fixtureInvalidPolygon
+    case geofenceInvalidPolygon
+    case kioskInvalidPolygon
+    case relationshipEndpointNotFound
+    case relationshipSelfReference
+    case sectionInvalidPolygon
 }
 
 public enum IMDFPreflightSeverity: String, Codable, CaseIterable, Sendable {
@@ -268,4 +410,10 @@ public enum IMDFPreflightFeature: String, Codable, CaseIterable, Sendable {
     case unit
     case anchor
     case occupant
+    case detail
+    case fixture
+    case geofence
+    case kiosk
+    case relationship
+    case section
 }

--- a/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/DomainModelTests.swift
@@ -12,6 +12,34 @@ final class DomainModelTests: XCTestCase {
             category: .lobby,
             coordinates: coordinates
         )
+        let detail = Detail(
+            id: try uuid("00000000-0000-0000-0000-000000000007"),
+            name: "Wall Detail",
+            coordinates: lineCoordinates()
+        )
+        let fixture = Fixture(
+            id: try uuid("00000000-0000-0000-0000-000000000008"),
+            name: "Desk",
+            category: .desk,
+            coordinates: coordinates
+        )
+        let geofence = Geofence(
+            id: try uuid("00000000-0000-0000-0000-000000000009"),
+            name: "Paid Area",
+            category: .paidArea,
+            coordinates: coordinates
+        )
+        let kiosk = Kiosk(
+            id: try uuid("00000000-0000-0000-0000-000000000010"),
+            name: "Info Kiosk",
+            coordinates: coordinates
+        )
+        let section = Section(
+            id: try uuid("00000000-0000-0000-0000-000000000011"),
+            name: "Gate Area",
+            category: .gateArea,
+            coordinates: coordinates
+        )
         let level = Level(
             id: try uuid("00000000-0000-0000-0000-000000000002"),
             name: "Level 1",
@@ -19,7 +47,12 @@ final class DomainModelTests: XCTestCase {
             ordinal: 0,
             shortName: "1F",
             coordinates: coordinates,
-            units: [unit]
+            units: [unit],
+            details: [detail],
+            fixtures: [fixture],
+            geofences: [geofence],
+            kiosks: [kiosk],
+            sections: [section]
         )
         let footprint = Footprint(
             id: try uuid("00000000-0000-0000-0000-000000000003"),
@@ -41,6 +74,12 @@ final class DomainModelTests: XCTestCase {
             country: "US",
             postalCode: "95014"
         )
+        let relationship = Relationship(
+            id: try uuid("00000000-0000-0000-0000-000000000012"),
+            category: .stairs,
+            originID: unit.id,
+            destinationID: section.id
+        )
 
         // When
         let venue = Venue(
@@ -49,7 +88,8 @@ final class DomainModelTests: XCTestCase {
             category: .university,
             coordinates: coordinates,
             buildings: [building],
-            address: address
+            address: address,
+            relationships: [relationship]
         )
 
         // Then
@@ -60,9 +100,15 @@ final class DomainModelTests: XCTestCase {
         XCTAssertEqual(venue.buildings.first?.levels.first?.category, .unspecified)
         XCTAssertEqual(venue.buildings.first?.levels.first?.coordinates, coordinates)
         XCTAssertEqual(venue.buildings.first?.levels.first?.units.first?.id, unit.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.details.first?.id, detail.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.fixtures.first?.id, fixture.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.geofences.first?.id, geofence.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.kiosks.first?.id, kiosk.id)
+        XCTAssertEqual(venue.buildings.first?.levels.first?.sections.first?.id, section.id)
         XCTAssertEqual(venue.buildings.first?.footprint?.id, footprint.id)
         XCTAssertEqual(venue.buildings.first?.footprint?.category, .ground)
         XCTAssertEqual(venue.address?.id, address.id)
+        XCTAssertEqual(venue.relationships.first?.id, relationship.id)
     }
 
     func test_whenCoordinatesShareLatitudeAndLongitude_thenTheyAreEqual() {
@@ -116,7 +162,14 @@ final class DomainModelTests: XCTestCase {
             OccupantCategory.medical.rawValue,
             OccupantCategory.government.rawValue,
             OccupantCategory.entertainment.rawValue,
-            OccupantCategory.service.rawValue
+            OccupantCategory.service.rawValue,
+            FixtureCategory.desk.rawValue,
+            FixtureCategory.checkInDesk.rawValue,
+            GeofenceCategory.paidArea.rawValue,
+            RelationshipCategory.movingWalkway.rawValue,
+            RelationshipCategory.traversalPath.rawValue,
+            SectionCategory.gateArea.rawValue,
+            SectionCategory.postSecurity.rawValue
         ]
 
         // When
@@ -141,7 +194,14 @@ final class DomainModelTests: XCTestCase {
             "medicalcenter",
             "publicservices.government",
             "arts.entertainment",
-            "localservices"
+            "localservices",
+            "desk",
+            "checkin.desk",
+            "paidarea",
+            "movingwalkway",
+            "traversal.path",
+            "gatearea",
+            "postsecurity"
         ]
 
         // Then
@@ -158,6 +218,13 @@ final class DomainModelTests: XCTestCase {
             Coordinate(latitude: 37.33170, longitude: -122.03090),
             Coordinate(latitude: 37.33190, longitude: -122.03090),
             Coordinate(latitude: 37.33190, longitude: -122.03110)
+        ]
+    }
+
+    private func lineCoordinates() -> [Coordinate] {
+        [
+            Coordinate(latitude: 37.33175, longitude: -122.03105),
+            Coordinate(latitude: 37.33185, longitude: -122.03100)
         ]
     }
 }

--- a/IMDFlex/Projects/Domain/Tests/IMDFPreflightValidatorTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/IMDFPreflightValidatorTests.swift
@@ -155,6 +155,51 @@ final class IMDFPreflightValidatorTests: XCTestCase {
         XCTAssertEqual(issues.first?.featureID, anchorID)
     }
 
+    func test_whenAllFeatureMVPGeometryAndRelationshipsAreInvalid_thenValidatorReturnsFeatureIssues() {
+        // Given
+        let sut = makeSUT()
+        let unit = makeUnitFixture()
+        let level = Level(
+            name: "Level 1",
+            ordinal: 0,
+            shortName: "1F",
+            coordinates: squareCoordinates(),
+            units: [unit],
+            details: [Detail(coordinates: [Coordinate(latitude: 37.0, longitude: -122.0)])],
+            fixtures: [Fixture(coordinates: [])],
+            geofences: [Geofence(coordinates: [])],
+            kiosks: [Kiosk(coordinates: [])],
+            sections: [Section(coordinates: [])]
+        )
+        let relationship = Relationship(
+            category: .traversal,
+            originID: unit.id,
+            destinationID: UUID()
+        )
+        let building = Building(name: "Main", levels: [level], footprint: makeFootprintFixture())
+        let venue = makeVenueFixture(buildings: [building], relationships: [relationship])
+
+        // When
+        let issues = sut.validate(venue)
+
+        // Then
+        XCTAssertEqual(
+            issueCodes(in: issues),
+            [
+                .relationshipEndpointNotFound,
+                .detailInvalidLine,
+                .fixtureInvalidPolygon,
+                .geofenceInvalidPolygon,
+                .kioskInvalidPolygon,
+                .sectionInvalidPolygon
+            ]
+        )
+        XCTAssertEqual(
+            issues.map(\.feature),
+            [.relationship, .detail, .fixture, .geofence, .kiosk, .section]
+        )
+    }
+
     func test_whenIssueIsCreated_thenIDIncludesCodeFeatureAndFeatureID() throws {
         // Given
         let featureID = try XCTUnwrap(UUID(uuidString: "00000000-0000-0000-0000-000000000017"))
@@ -177,7 +222,10 @@ final class IMDFPreflightValidatorTests: XCTestCase {
         IMDFPreflightValidator()
     }
 
-    private func makeVenueFixture(buildings: [Building]? = nil) -> Venue {
+    private func makeVenueFixture(
+        buildings: [Building]? = nil,
+        relationships: [Relationship] = []
+    ) -> Venue {
         Venue(
             name: "Valid Venue",
             category: .university,
@@ -189,7 +237,8 @@ final class IMDFPreflightValidatorTests: XCTestCase {
                 province: "CA",
                 country: "US",
                 postalCode: "95014"
-            )
+            ),
+            relationships: relationships
         )
     }
 

--- a/docs/IMDF-Generator-migration.md
+++ b/docs/IMDF-Generator-migration.md
@@ -13,7 +13,7 @@ IMDFlex continues the product direction from `luminouxx/IMDF-Generator`, but kee
 
 ## MVP Feature Scope
 
-The MVP targets these IMDF feature collections:
+The MVP now targets every Apple IMDF feature collection, while keeping manual authoring depth simple at first:
 
 - `address.geojson`
 - `venue.geojson`
@@ -23,7 +23,14 @@ The MVP targets these IMDF feature collections:
 - `unit.geojson`
 - `opening.geojson`
 - `amenity.geojson`
+- `anchor.geojson`
 - `occupant.geojson`
+- `detail.geojson`
+- `fixture.geojson`
+- `geofence.geojson`
+- `kiosk.geojson`
+- `relationship.geojson`
+- `section.geojson`
 
 ## Product Workflow
 
@@ -50,4 +57,4 @@ The MVP targets these IMDF feature collections:
 4. Port and redesign the image overlay alignment flow for level-specific floor plans.
 5. Replace the current nested Domain aggregate with explicit feature repositories if editing complexity grows.
 
-See `docs/imdf-schema-gap.md` for the current Apple IMDF validation and category gap analysis.
+See `docs/all-imdf-feature-mvp-plan.md` for the all-feature MVP implementation plan and `docs/imdf-schema-gap.md` for the current Apple IMDF validation and category gap analysis.

--- a/docs/all-imdf-feature-mvp-plan.md
+++ b/docs/all-imdf-feature-mvp-plan.md
@@ -1,0 +1,73 @@
+# All IMDF Feature MVP Plan
+
+This document records the product and implementation plan for expanding IMDFlex MVP support from a core IMDF subset to every Apple IMDF feature collection.
+
+## Source Baseline
+
+- Apple resource page: `https://register.apple.com/resources/imdf/`
+- Apple IMDF version shown by the resource page: `1.0.0`
+- Apple resource page last update: `October 19, 2021`
+- Assets analyzed locally: `/private/tmp/IMDF-assets`
+- Validation CSV analyzed: `imdf-validations-1.0.3.csv`
+- Category CSV analyzed: `categories_20210728.csv`
+
+Apple IMDF Sandbox and Apple IMDF Validator remain the source of truth. Local implementation and tests are preflight aids only.
+
+## MVP Definition
+
+The MVP should be able to represent, validate locally, and export every Apple IMDF feature collection. Editor UX can stay shallow and manual at first.
+
+In practice, MVP means:
+
+- Every IMDF feature file is present in `imdf.zip`.
+- Empty optional collections still export valid GeoJSON `FeatureCollection` files.
+- Authored features preserve IDs and references.
+- Required geometry/category/reference fields have local model-level preflight checks.
+- Advanced topology checks are documented and deferred unless they can be implemented safely without a geometry engine.
+- Apple Sandbox/Validator success is not claimed until run against an exported archive.
+
+## Feature Collections
+
+| File | Geometry | Primary required references | MVP authoring tool |
+| --- | --- | --- | --- |
+| `address.geojson` | `null` | Referenced by `venue` | Form |
+| `venue.geojson` | `Polygon` | `address_id` | Polygon |
+| `building.geojson` | `null` | Referenced by `footprint` and `level` | Form + display point |
+| `footprint.geojson` | `Polygon` | `building_id` | Polygon |
+| `level.geojson` | `Polygon` | `building_id` | Polygon |
+| `unit.geojson` | `Polygon` | `level_id` | Polygon |
+| `opening.geojson` | `LineString` | `level_id` | Line |
+| `amenity.geojson` | `Point` | `unit_id` | Point |
+| `anchor.geojson` | `Point` | `unit_id` | Point |
+| `occupant.geojson` | `null` | `anchor_id` | Form |
+| `detail.geojson` | `LineString` | `level_id` | Line |
+| `fixture.geojson` | `Polygon` | `level_id`, optional contained anchors | Polygon |
+| `geofence.geojson` | `Polygon` | `level_id` or `building_id` | Polygon |
+| `kiosk.geojson` | `Polygon` | `level_id`, optional contained anchors | Polygon |
+| `relationship.geojson` | `null` | referenced feature IDs | Form |
+| `section.geojson` | `Polygon` | `level_id` | Polygon |
+
+## Implementation Order
+
+1. Documentation contract: update agent instructions, migration notes, and schema gap docs around the all-feature MVP.
+2. Domain layer: add missing feature entities and containment in existing aggregates.
+3. Exporter layer: export every feature file and preserve basic references.
+4. Preflight layer: validate missing geometry/category/reference issues for all MVP features.
+5. Presentation layer: add feature-type selection and reuse point/line/polygon tools for every feature.
+
+## Commit Strategy
+
+This scope should be committed in reviewable layers:
+
+1. `docs:` all-feature MVP contract.
+2. `feat:` Domain entities and model tests.
+3. `feat:` exporter support and Data tests.
+4. `feat:` preflight support, docs, final verification.
+
+## Deferred Work
+
+- Full polygon containment and coverage validation.
+- Self-intersection detection beyond Apple Validator.
+- Complete category lists for `amenity` and `occupant`.
+- Rich editor UX for every feature.
+- Apple IMDF Sandbox automation.

--- a/docs/all-imdf-feature-mvp-plan.md
+++ b/docs/all-imdf-feature-mvp-plan.md
@@ -69,5 +69,7 @@ This scope should be committed in reviewable layers:
 - Full polygon containment and coverage validation.
 - Self-intersection detection beyond Apple Validator.
 - Complete category lists for `amenity` and `occupant`.
+- Official confirmation of `relationship.direction` accepted values.
+- Official confirmation of `relationship` endpoint property names.
 - Rich editor UX for every feature.
 - Apple IMDF Sandbox automation.

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -129,7 +129,7 @@ Apple validation includes rules for these feature collections that were not part
 - `Relationship`: `RelationshipMustHaveCategory`, `RelationshipCategoryMustBeValid`, `RelationshipDirectionMustBeValid`
 - `Section`: `SectionMustHavePolygonalGeometry`, `SectionMustReferenceLevel`, `SectionMustHaveCategory`
 
-Current Domain/export support for these features is being added as shallow MVP coverage. Full topology validations such as feature coverage, display point containment, and anchor containment should remain documented as Apple Validator confirmation work.
+Current Domain/export support for these features is implemented as shallow MVP coverage. Local preflight checks basic geometry and relationship endpoint resolution. Full topology validations such as feature coverage, display point containment, and anchor containment remain Apple Validator confirmation work.
 
 ## Feature-Level Gap Table
 
@@ -146,12 +146,12 @@ Current Domain/export support for these features is being added as shallow MVP c
 | Amenity | Model exists | Coordinate optional but point geometry required; category values incomplete | P1 |
 | Occupant | Model exists with anchor reference | Category values incomplete; Sandbox confirmation pending | P1 |
 | Anchor | Model and export exist locally | Coverage by referenced unit not yet checked locally | P1 |
-| Detail | Planned in all-feature MVP | Model/export/preflight missing | P0 |
-| Fixture | Planned in all-feature MVP | Model/export/preflight missing | P0 |
-| Geofence | Planned in all-feature MVP | Model/export/preflight missing | P0 |
-| Kiosk | Planned in all-feature MVP | Model/export/preflight missing | P0 |
-| Relationship | Planned in all-feature MVP | Model/export/preflight missing | P0 |
-| Section | Planned in all-feature MVP | Model/export/preflight missing | P0 |
+| Detail | Model/export/preflight exists locally | Topology and Sandbox confirmation pending | P1 |
+| Fixture | Model/export/preflight exists locally | Anchor containment and Sandbox confirmation pending | P1 |
+| Geofence | Model/export/preflight exists locally | Level/building reference strategy and Sandbox confirmation pending | P1 |
+| Kiosk | Model/export/preflight exists locally | Anchor containment and Sandbox confirmation pending | P1 |
+| Relationship | Model/export/preflight exists locally | Direction/property names need official Validator confirmation | P1 |
+| Section | Model/export/preflight exists locally | Coverage/display point containment pending | P1 |
 
 ## Apple Category Baseline For MVP
 
@@ -184,10 +184,10 @@ Use Apple category values as raw export values.
 ## Recommended Implementation Order
 
 1. Keep existing core feature export and tests. Done locally; Apple Sandbox confirmation pending.
-2. Add all-feature MVP contract documentation. In progress.
-3. Add Domain models for `detail`, `fixture`, `geofence`, `kiosk`, `relationship`, and `section`.
-4. Extend `IMDFExporter` to write every IMDF feature collection.
-5. Extend local preflight to cover required geometry, category, and references for all MVP features.
+2. Add all-feature MVP contract documentation. Done locally.
+3. Add Domain models for `detail`, `fixture`, `geofence`, `kiosk`, `relationship`, and `section`. Done locally.
+4. Extend `IMDFExporter` to write every IMDF feature collection. Done locally.
+5. Extend local preflight to cover required geometry, category, and references for all MVP features. Done locally for model-level checks.
 6. Add module tests:
    - `Domain`: entity construction and category raw values.
    - `Data`: exported ZIP file list and GeoJSON structure.
@@ -212,12 +212,21 @@ The first local preflight pass checks model-level issues that can be detected wi
 - Occupant has a category.
 - Occupant references an anchor.
 - Occupant anchor reference resolves to an anchor in the same unit.
+- Detail has enough coordinates to form a line.
+- Fixture has enough coordinates to form a polygon.
+- Geofence has enough coordinates to form a polygon.
+- Kiosk has enough coordinates to form a polygon.
+- Section has enough coordinates to form a polygon.
+- Relationship origin/destination references resolve to authored features.
+- Relationship origin and destination are not the same feature.
 
 The preflight validator intentionally does not yet prove:
 
 - Venue polygon covers all child features.
 - Display points are contained by their parent polygons.
 - Level/unit/footprint coverage is topologically correct.
+- Fixture/kiosk anchor containment is topologically correct.
+- Relationship property names and direction values are accepted by Apple IMDF Validator.
 - Apple IMDF Sandbox acceptance.
 
 ## Open Questions

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -1,6 +1,6 @@
 # IMDF Schema Gap
 
-This document tracks gaps between IMDFlex's current Domain/export model and Apple's official IMDF resources.
+This document tracks gaps between IMDFlex's current Domain/export model and Apple's official IMDF resources. The MVP scope now includes every Apple IMDF feature collection, with shallow manual authoring first.
 
 ## Source Baseline
 
@@ -118,21 +118,40 @@ Remaining direction:
 - Add topology checks for anchor coverage by the referenced unit.
 - Decide whether anchors can later be reused by fixtures, kiosks, or other IMDF features.
 
+### 7. Remaining IMDF Feature Collections Are Now MVP Scope
+
+Apple validation includes rules for these feature collections that were not part of the original core MVP:
+
+- `Detail`: `DetailMustHaveLinealGeometry`, `DetailMustReferenceLevel`
+- `Fixture`: `FixtureMustHavePolygonalGeometry`, `FixtureMustReferenceLevel`, `FixtureMustHaveCategory`
+- `Geofence`: `GeofenceMustHavePolygonalGeometry`, `GeofenceMustHaveCategory`, `GeofenceMustHaveLevelOrBuildingReference`
+- `Kiosk`: `KioskMustHavePolygonalGeometry`, `KioskMustReferenceLevel`
+- `Relationship`: `RelationshipMustHaveCategory`, `RelationshipCategoryMustBeValid`, `RelationshipDirectionMustBeValid`
+- `Section`: `SectionMustHavePolygonalGeometry`, `SectionMustReferenceLevel`, `SectionMustHaveCategory`
+
+Current Domain/export support for these features is being added as shallow MVP coverage. Full topology validations such as feature coverage, display point containment, and anchor containment should remain documented as Apple Validator confirmation work.
+
 ## Feature-Level Gap Table
 
 | Feature | Current Status | Validator-Risk Gap | Priority |
 | --- | --- | --- | --- |
-| Manifest | Not exported | Required manifest missing | P0 |
+| Manifest | Export exists locally | Sandbox confirmation pending | P0 |
 | Address | Basic model exists | ISO country/province fields and reference semantics need review | P1 |
-| Venue | Model exists | Missing polygon geometry and display point | P0 |
-| Building | Model exists | Missing category; must have footprint and level references | P0 |
-| Footprint | Model exists | Missing category | P0 |
-| Level | Model exists | Missing polygon geometry and category; short name optional | P0 |
-| Unit | Model exists | Category values need Apple alignment; level containment needs preflight | P1 |
-| Opening | Model exists | Category/access-control values need Apple alignment | P1 |
+| Venue | Model/export exists locally | Display point containment and coverage pending | P1 |
+| Building | Model/export exists locally | Display point containment and relationship preflight pending | P1 |
+| Footprint | Model/export exists locally | Topology rules pending | P1 |
+| Level | Model/export exists locally | Coverage by units and containment pending | P1 |
+| Unit | Model/export exists locally | Level containment and accessibility/restriction expansion pending | P1 |
+| Opening | Model/export exists locally | Unit boundary coverage and door metadata pending | P1 |
 | Amenity | Model exists | Coordinate optional but point geometry required; category values incomplete | P1 |
 | Occupant | Model exists with anchor reference | Category values incomplete; Sandbox confirmation pending | P1 |
 | Anchor | Model and export exist locally | Coverage by referenced unit not yet checked locally | P1 |
+| Detail | Planned in all-feature MVP | Model/export/preflight missing | P0 |
+| Fixture | Planned in all-feature MVP | Model/export/preflight missing | P0 |
+| Geofence | Planned in all-feature MVP | Model/export/preflight missing | P0 |
+| Kiosk | Planned in all-feature MVP | Model/export/preflight missing | P0 |
+| Relationship | Planned in all-feature MVP | Model/export/preflight missing | P0 |
+| Section | Planned in all-feature MVP | Model/export/preflight missing | P0 |
 
 ## Apple Category Baseline For MVP
 
@@ -164,11 +183,11 @@ Use Apple category values as raw export values.
 
 ## Recommended Implementation Order
 
-1. Add `manifest.json` export and tests. Done locally; Apple Sandbox confirmation pending.
-2. Add explicit geometry/category fields for `Venue`, `Building`, `Footprint`, and `Level`. Done locally; Apple Sandbox confirmation pending.
-3. Align remaining MVP category enums with Apple category CSV raw values. Curated MVP presets are aligned locally; full category strategy remains open.
-4. Add a preflight validator for required relationships and required geometry. Started locally with model-level required data checks.
-5. Add `Occupant + Anchor` relationship support before exporting occupants as Apple-submission data. Done locally; Apple Sandbox confirmation pending.
+1. Keep existing core feature export and tests. Done locally; Apple Sandbox confirmation pending.
+2. Add all-feature MVP contract documentation. In progress.
+3. Add Domain models for `detail`, `fixture`, `geofence`, `kiosk`, `relationship`, and `section`.
+4. Extend `IMDFExporter` to write every IMDF feature collection.
+5. Extend local preflight to cover required geometry, category, and references for all MVP features.
 6. Add module tests:
    - `Domain`: entity construction and category raw values.
    - `Data`: exported ZIP file list and GeoJSON structure.


### PR DESCRIPTION
## Summary

Expands the IMDFlex MVP from a core IMDF feature subset to shallow support for every Apple IMDF feature collection.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Reframed AGENTS and docs around an all-feature IMDF MVP.
- Added Domain models for `detail`, `fixture`, `geofence`, `kiosk`, `relationship`, and `section`.
- Extended `Level` and `Venue` containment so all new features can be represented.
- Extended `IMDFExporter` to include every IMDF GeoJSON feature collection in `imdf.zip`.
- Added local preflight checks for new feature geometry and relationship endpoints.
- Added GWT-style Domain/Data tests for model preservation, category values, ZIP entries, GeoJSON shapes, and preflight issues.

## IMDF Impact

- `imdf.zip` now includes:
  - `detail.geojson`
  - `fixture.geojson`
  - `geofence.geojson`
  - `kiosk.geojson`
  - `relationship.geojson`
  - `section.geojson`
- Existing core feature exports remain in place.
- Local preflight now checks detail line geometry, fixture/geofence/kiosk/section polygon geometry, and relationship endpoint resolution.
- Apple IMDF Sandbox / Validator acceptance is still pending and is not claimed by this PR.
- `relationship.direction` values and relationship endpoint property names are documented as official Validator confirmation items.

## Architecture Notes

- Domain remains independent of Data and UI concerns.
- Data consumes public Domain models only.
- The existing nested aggregate remains in place for MVP authoring. If editing complexity grows, feature repositories can be split later.
- No third-party dependencies were added.

## Verification

- [x] `Domain`: `mise exec -- tuist test Domain` passed, 18 tests.
- [x] `Data`: `mise exec -- tuist test Data` passed, 7 tests.
- [x] `Presentation`: compiled through `mise exec -- tuist build IMDFlex`.
- [x] `DesignSystem`: included in `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [x] `mise exec -- tuist generate --no-binary-cache --no-open`: not run; no Tuist manifest changes.
- [x] Apple IMDF Validator / preflight: Apple Sandbox/Validator not run locally; local preflight tests passed.

## Screenshots Or Recording

Not applicable; no UI changes.

## Related Issues

Closes #23

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
