### PR TITLE
feat: add IMDF category catalog foundation

### DIFF
--- a/IMDFlex/Projects/Domain/Sources/Entities/IMDFCategoryCatalog.swift
+++ b/IMDFlex/Projects/Domain/Sources/Entities/IMDFCategoryCatalog.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+/// Apple IMDF category collection names from `categories_20210728.csv`.
+public enum IMDFCategoryFeature: String, Codable, CaseIterable, Sendable {
+    case accessControl = "access-control"
+    case accessibility
+    case amenity
+    case building
+    case door
+    case doorMaterial = "door-material"
+    case fixture
+    case footprint
+    case geofence
+    case level
+    case occupant
+    case opening
+    case relationship
+    case restriction
+    case section
+    case unit
+    case venue
+}
+
+public struct IMDFCategoryEntry: Identifiable, Codable, Equatable, Sendable {
+    public var feature: IMDFCategoryFeature
+    public var value: String
+    public var definition: String?
+
+    public var id: String {
+        [feature.rawValue, value].joined(separator: ":")
+    }
+
+    public init(
+        feature: IMDFCategoryFeature,
+        value: String,
+        definition: String? = nil
+    ) {
+        self.feature = feature
+        self.value = value
+        self.definition = definition
+    }
+}
+
+public struct IMDFCategoryFeatureSummary: Codable, Equatable, Sendable {
+    public var feature: IMDFCategoryFeature
+    public var categoryCount: Int
+    public var representativeValues: [String]
+
+    public init(
+        feature: IMDFCategoryFeature,
+        categoryCount: Int,
+        representativeValues: [String]
+    ) {
+        self.feature = feature
+        self.categoryCount = categoryCount
+        self.representativeValues = representativeValues
+    }
+}
+
+public struct IMDFCategoryCatalog: Codable, Equatable, Sendable {
+    public var entries: [IMDFCategoryEntry]
+
+    public init(entries: [IMDFCategoryEntry]) {
+        self.entries = entries
+    }
+
+    public func entries(for feature: IMDFCategoryFeature) -> [IMDFCategoryEntry] {
+        entries.filter { $0.feature == feature }
+    }
+
+    public func contains(_ value: String, for feature: IMDFCategoryFeature) -> Bool {
+        entries.contains { $0.feature == feature && $0.value == value }
+    }
+}
+
+public enum IMDFCategoryCatalogSource: Sendable {
+    public static let appleCategories20210728FileName = "categories_20210728.csv"
+
+    public static let appleCategories20210728FeatureSummaries: [IMDFCategoryFeatureSummary] = [
+        .init(feature: .accessControl, categoryCount: 8, representativeValues: [
+            "badgereader", "fingerprintreader", "guard", "keyaccess"
+        ]),
+        .init(feature: .accessibility, categoryCount: 10, representativeValues: [
+            "assisted.listening", "braille", "hearing", "wheelchair"
+        ]),
+        .init(feature: .amenity, categoryCount: 172, representativeValues: [
+            "atm", "drinkingfountain", "firstaid", "restroom.male"
+        ]),
+        .init(feature: .building, categoryCount: 5, representativeValues: [
+            "parking", "transit", "transit.bus", "unspecified"
+        ]),
+        .init(feature: .door, categoryCount: 11, representativeValues: [
+            "door", "open", "revolving", "turnstile"
+        ]),
+        .init(feature: .doorMaterial, categoryCount: 4, representativeValues: [
+            "gate", "glass", "metal", "wood"
+        ]),
+        .init(feature: .fixture, categoryCount: 15, representativeValues: [
+            "baggagecarousel", "checkin.desk", "furniture", "wall"
+        ]),
+        .init(feature: .footprint, categoryCount: 3, representativeValues: [
+            "aerial", "ground", "subterranean"
+        ]),
+        .init(feature: .geofence, categoryCount: 8, representativeValues: [
+            "concourse", "paidarea", "postsecurity", "terminal"
+        ]),
+        .init(feature: .level, categoryCount: 9, representativeValues: [
+            "arrivals", "departures", "parking", "unspecified"
+        ]),
+        .init(feature: .occupant, categoryCount: 1116, representativeValues: [
+            "3dprinting", "acai", "airportloungebar", "corporateoffices"
+        ]),
+        .init(feature: .opening, categoryCount: 7, representativeValues: [
+            "automobile", "emergencyexit", "pedestrian.principal", "service"
+        ]),
+        .init(feature: .relationship, categoryCount: 7, representativeValues: [
+            "elevator", "movingwalkway", "traversal", "traversal.path"
+        ]),
+        .init(feature: .restriction, categoryCount: 2, representativeValues: [
+            "employeesonly", "restricted"
+        ]),
+        .init(feature: .section, categoryCount: 71, representativeValues: [
+            "baggageclaim", "gatearea", "postsecurity", "walkway"
+        ]),
+        .init(feature: .unit, categoryCount: 63, representativeValues: [
+            "foodservice", "restroom.male", "structure", "walkway"
+        ]),
+        .init(feature: .venue, categoryCount: 22, representativeValues: [
+            "airport", "parkingfacility", "shoppingcenter", "university"
+        ])
+    ]
+}

--- a/IMDFlex/Projects/Domain/Tests/IMDFCategoryCatalogTests.swift
+++ b/IMDFlex/Projects/Domain/Tests/IMDFCategoryCatalogTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import Domain
+
+final class IMDFCategoryCatalogTests: XCTestCase {
+    func test_whenAppleCategorySummariesAreLoaded_thenTheyMatchOfficialFeatureCounts() {
+        // Given
+        let summaries = IMDFCategoryCatalogSource.appleCategories20210728FeatureSummaries
+
+        // When
+        let countsByFeature = Dictionary(uniqueKeysWithValues: summaries.map { ($0.feature, $0.categoryCount) })
+
+        // Then
+        XCTAssertEqual(countsByFeature[.accessControl], 8)
+        XCTAssertEqual(countsByFeature[.accessibility], 10)
+        XCTAssertEqual(countsByFeature[.amenity], 172)
+        XCTAssertEqual(countsByFeature[.building], 5)
+        XCTAssertEqual(countsByFeature[.door], 11)
+        XCTAssertEqual(countsByFeature[.doorMaterial], 4)
+        XCTAssertEqual(countsByFeature[.fixture], 15)
+        XCTAssertEqual(countsByFeature[.footprint], 3)
+        XCTAssertEqual(countsByFeature[.geofence], 8)
+        XCTAssertEqual(countsByFeature[.level], 9)
+        XCTAssertEqual(countsByFeature[.occupant], 1116)
+        XCTAssertEqual(countsByFeature[.opening], 7)
+        XCTAssertEqual(countsByFeature[.relationship], 7)
+        XCTAssertEqual(countsByFeature[.restriction], 2)
+        XCTAssertEqual(countsByFeature[.section], 71)
+        XCTAssertEqual(countsByFeature[.unit], 63)
+        XCTAssertEqual(countsByFeature[.venue], 22)
+    }
+
+    func test_whenRepresentativeValuesAreLoaded_thenTheyContainAppleRawCategoryValues() throws {
+        // Given
+        let summaries = IMDFCategoryCatalogSource.appleCategories20210728FeatureSummaries
+
+        // When
+        let amenity = try XCTUnwrap(summaries.first { $0.feature == .amenity })
+        let occupant = try XCTUnwrap(summaries.first { $0.feature == .occupant })
+        let section = try XCTUnwrap(summaries.first { $0.feature == .section })
+        let unit = try XCTUnwrap(summaries.first { $0.feature == .unit })
+
+        // Then
+        XCTAssertTrue(amenity.representativeValues.contains("drinkingfountain"))
+        XCTAssertTrue(occupant.representativeValues.contains("corporateoffices"))
+        XCTAssertTrue(section.representativeValues.contains("gatearea"))
+        XCTAssertTrue(unit.representativeValues.contains("foodservice"))
+    }
+
+    func test_whenCatalogContainsEntry_thenLookupUsesFeatureAndRawValue() {
+        // Given
+        let sut = IMDFCategoryCatalog(entries: [
+            .init(feature: .venue, value: "shoppingcenter"),
+            .init(feature: .unit, value: "walkway")
+        ])
+
+        // When
+        let venueEntries = sut.entries(for: .venue)
+
+        // Then
+        XCTAssertEqual(venueEntries, [.init(feature: .venue, value: "shoppingcenter")])
+        XCTAssertTrue(sut.contains("shoppingcenter", for: .venue))
+        XCTAssertFalse(sut.contains("shoppingcenter", for: .unit))
+    }
+}

--- a/docs/imdf-category-catalog.md
+++ b/docs/imdf-category-catalog.md
@@ -1,0 +1,62 @@
+# IMDF Category Catalog Strategy
+
+This document records how IMDFlex should use Apple's `categories_20210728.csv`.
+
+## Source
+
+- Source file reviewed locally: `/Users/luminoux/Downloads/IMDF/categories_20210728.csv`
+- CSV columns: `collection`, `venueType`, `feature`, `category`, `definition`
+- Official Apple resource baseline remains `https://register.apple.com/resources/imdf/`
+
+Do not claim Apple submission readiness from this file alone. Apple IMDF Validator remains the source of truth for final acceptance.
+
+## Feature Counts
+
+The CSV contains these distinct category counts by `feature`:
+
+| Feature | Count |
+| --- | ---: |
+| `access-control` | 8 |
+| `accessibility` | 10 |
+| `amenity` | 172 |
+| `building` | 5 |
+| `door` | 11 |
+| `door-material` | 4 |
+| `fixture` | 15 |
+| `footprint` | 3 |
+| `geofence` | 8 |
+| `level` | 9 |
+| `occupant` | 1116 |
+| `opening` | 7 |
+| `relationship` | 7 |
+| `restriction` | 2 |
+| `section` | 71 |
+| `unit` | 63 |
+| `venue` | 22 |
+
+## Strategy
+
+Use two layers:
+
+1. Curated Swift enums for common presets already used by Domain models and tests.
+2. `IMDFCategoryCatalog` for the full Apple category universe and future picker/search UI.
+
+This avoids generating huge Swift enums for sets such as `occupant` while still keeping Apple raw values available for validation and selection.
+
+## Current Implementation
+
+`IMDFCategoryCatalog` currently provides:
+
+- `IMDFCategoryFeature`: feature/category collection identifiers.
+- `IMDFCategoryEntry`: a feature-scoped raw category value plus optional definition.
+- `IMDFCategoryCatalog`: lookup by feature and raw value.
+- `IMDFCategoryCatalogSource.appleCategories20210728FeatureSummaries`: official count summaries and representative values used by tests.
+
+The full CSV is not bundled into the app yet.
+
+## Next Steps
+
+1. Decide whether the full catalog should be stored as a bundled CSV/JSON resource or generated Swift data.
+2. Add a parser/loader in `Data` if bundling a CSV or JSON resource.
+3. Let Presentation category pickers query the catalog by feature type.
+4. Gradually allow Domain feature categories to preserve raw strings in addition to curated enum presets.

--- a/docs/imdf-schema-gap.md
+++ b/docs/imdf-schema-gap.md
@@ -98,9 +98,11 @@ Resolved examples:
 
 Remaining direction:
 
-- Decide whether full Apple category lists should be modeled as enums, raw strings, or curated presets.
+- Use curated Swift enums as common presets and `IMDFCategoryCatalog` as the full Apple raw-value foundation.
 - Add UI-facing labels separate from IMDF raw values.
 - Continue adding tests when new category presets are introduced.
+
+See `docs/imdf-category-catalog.md` for the category catalog strategy.
 
 ### 6. Occupant Requires Anchor
 


### PR DESCRIPTION
## Summary

Adds a Domain foundation for Apple IMDF category catalogs, using `categories_20210728.csv` counts and representative raw values as the baseline.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added `IMDFCategoryFeature`, `IMDFCategoryEntry`, `IMDFCategoryCatalog`, and official summary metadata.
- Added GWT-style Domain tests for official feature counts, representative Apple raw values, and catalog lookup behavior.
- Documented the curated enum + full catalog strategy in `docs/imdf-category-catalog.md`.
- Linked the category catalog strategy from `docs/imdf-schema-gap.md`.

## IMDF Impact

- Establishes a path to support the full Apple category universe without generating very large Swift enums, especially for `occupant` and `amenity`.
- Existing category enums and exporter behavior are unchanged.
- The full CSV is not bundled into the app yet; this PR records the foundation and official count baseline.

## Architecture Notes

- Domain owns the catalog value types and source summary metadata.
- Data/Persistence loading for a bundled CSV or generated data file is deferred.
- Presentation category picker/search UI is deferred.
- No third-party dependencies were added.

## Verification

- [x] `Domain`: `mise exec -- tuist test Domain` passed, 21 tests.
- [ ] `Data`: not directly tested; no Data behavior changed.
- [x] `Presentation`: compiled through `mise exec -- tuist build IMDFlex`.
- [x] `DesignSystem`: included in `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`: not run; no Tuist manifest changes.
- [ ] Apple IMDF Validator / preflight: not run; category catalog foundation only.

## Screenshots Or Recording

Not applicable; no UI changes.

## Related Issues

Closes #25

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
