### PR TITLE
feat: add generated JSON category catalog loader

### DIFF
--- a/IMDFlex/Projects/Data/Project.swift
+++ b/IMDFlex/Projects/Data/Project.swift
@@ -3,5 +3,6 @@ import ProjectDescriptionHelpers
 
 let project = Project.module(
     module: .data,
-    dependencies: .dataDependencies
+    dependencies: .dataDependencies,
+    resources: ["Resources/**"]
 )

--- a/IMDFlex/Projects/Data/README.md
+++ b/IMDFlex/Projects/Data/README.md
@@ -8,6 +8,8 @@ Repository implementations and data sources.
 Sources/
 ├── Repositories/    # Protocol implementations
 └── DataSources/     # File I/O, JSON parsing
+Resources/
+└── *.json           # Generated bundled data resources
 ```
 
 ## Guidelines
@@ -23,6 +25,7 @@ Sources/
 ### DataSources
 - Keep I/O operations isolated
 - Handle encoding/decoding errors gracefully
+- Generated category catalog resources are loaded through `IMDFCategoryCatalogJSONLoader`
 
 ## Dependencies
 

--- a/IMDFlex/Projects/Data/Resources/IMDFCategoryCatalog.generated.json
+++ b/IMDFlex/Projects/Data/Resources/IMDFCategoryCatalog.generated.json
@@ -1,0 +1,7538 @@
+{
+  "entries": [
+    {
+      "feature": "access-control",
+      "value": "badgereader"
+    },
+    {
+      "feature": "access-control",
+      "value": "fingerprintreader"
+    },
+    {
+      "feature": "access-control",
+      "value": "guard"
+    },
+    {
+      "feature": "access-control",
+      "value": "keyaccess"
+    },
+    {
+      "feature": "access-control",
+      "value": "outofservice",
+      "definition": "Describes the operational status of an Opening or a Unit described in a Relationship."
+    },
+    {
+      "feature": "access-control",
+      "value": "passwordaccess"
+    },
+    {
+      "feature": "access-control",
+      "value": "retinascanner"
+    },
+    {
+      "feature": "access-control",
+      "value": "voicerecognition"
+    },
+    {
+      "feature": "accessibility",
+      "value": "assisted.listening",
+      "definition": "Describes the presence of an assisted listening service."
+    },
+    {
+      "feature": "accessibility",
+      "value": "braille",
+      "definition": "Indicates the presence of a device, service, equipment or physical environment that is designed for a pedestrian that is visually impaired."
+    },
+    {
+      "feature": "accessibility",
+      "value": "hearing",
+      "definition": "Describes the presence of a service provided to a pedestrian with a hearing disability."
+    },
+    {
+      "feature": "accessibility",
+      "value": "hearingloop",
+      "definition": "Describes the presence of a telephone that offers a Hearing Loop."
+    },
+    {
+      "feature": "accessibility",
+      "value": "signlanginterpreter",
+      "definition": "Describes the presence of a sign language interpreter service."
+    },
+    {
+      "feature": "accessibility",
+      "value": "tactilepaving",
+      "definition": "Describes the presence of a ground surface that is provided to a pedestrian with a sight disability."
+    },
+    {
+      "feature": "accessibility",
+      "value": "tdd",
+      "definition": "Describes the presence of a telephone device for the deaf which is a device used for text communications along a telephone line."
+    },
+    {
+      "feature": "accessibility",
+      "value": "trs",
+      "definition": "Describes the presence of a Telecommunications Relay Service which is a telephone service that allows persons with hearing or speech disabilities to place and receive telephone calls."
+    },
+    {
+      "feature": "accessibility",
+      "value": "volume",
+      "definition": "Describes the presence of a specialized telephone for persons with impaired hearing."
+    },
+    {
+      "feature": "accessibility",
+      "value": "wheelchair",
+      "definition": "Describes the presence of a building function that is offered to persons that experience disabilities."
+    },
+    {
+      "feature": "amenity",
+      "value": "amphitheater",
+      "definition": "Models the presence and approximate point location of an amphitheater."
+    },
+    {
+      "feature": "amenity",
+      "value": "animalreliefarea",
+      "definition": "A convenience area for service animal relief, often be equipped with water bowls and animal toiletries"
+    },
+    {
+      "feature": "amenity",
+      "value": "arrivalgate",
+      "definition": "Models the presence and approximate point location of an arrivals gate operation. In certain airports around the world, arrival gates are separately sign-posted from boarding gates."
+    },
+    {
+      "feature": "amenity",
+      "value": "atm"
+    },
+    {
+      "feature": "amenity",
+      "value": "babychanging",
+      "definition": "Location for the specific purpose of changing a baby, does not contain bathroom facilities."
+    },
+    {
+      "feature": "amenity",
+      "value": "baggagecarousel",
+      "definition": "Models the presence and approximate point location of an individual Baggage Carousel."
+    },
+    {
+      "feature": "amenity",
+      "value": "baggagecarousel.intl",
+      "definition": "Models the presence and approximate point location of an individual Baggage Carousel that is either dedicated or timed to support international arrival operations."
+    },
+    {
+      "feature": "amenity",
+      "value": "baggagecarts",
+      "definition": "Models the presence and approximate point location of a baggage/luggage trolley system."
+    },
+    {
+      "feature": "amenity",
+      "value": "baggageclaim",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a baggage claim operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "baggageclaim.oversize",
+      "definition": "Models the presence and approximate point location of a baggage claim area, desk, or service where special or oversized baggage may be re-claimed. Examples of oversized items include: Golf clubs, skis, lacrosse/hockey sticks and other sporting equipment. Also, pets traveling in crates."
+    },
+    {
+      "feature": "amenity",
+      "value": "baggagerecheck",
+      "definition": "Models the presence and approximate point location of a baggage recheck service."
+    },
+    {
+      "feature": "amenity",
+      "value": "baggagestorage",
+      "definition": "Models the presence and approximate point location of a baggage service or facility where baggage may be temporarily stored."
+    },
+    {
+      "feature": "amenity",
+      "value": "boardinggate",
+      "definition": "Models the presence and approximate point location of a boarding gate operation. `boardinggate` should be used when a location cannot be classified using any other category in the hierarchy. `boardinggate` is not further defined in IMDF."
+    },
+    {
+      "feature": "amenity",
+      "value": "boardinggate.aircraft",
+      "definition": "Models the presence and approximate point location of an aircraft boarding gate operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "boardinggate.bus",
+      "definition": "Models the presence and approximate point location of a bus boarding gate operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "boardinggate.ferry",
+      "definition": "Models the presence and approximate point location of a ferry boarding gate operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "boardinggate.train",
+      "definition": "Models the presence and approximate point location of a traint boarding gate operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "bus",
+      "definition": "Models the presence and approximate point location of one or more bus stop."
+    },
+    {
+      "feature": "amenity",
+      "value": "bus.muni",
+      "definition": "Models the presence and approximate point location of one or more bus stop that is serviced by a local transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "bus.national",
+      "definition": "Models the presence and approximate point location of one or more bus stop that is serviced by a national transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "businesscenter",
+      "definition": "Models the presence and approximate point location of a space that provides office facilities and services to the public."
+    },
+    {
+      "feature": "amenity",
+      "value": "cabin"
+    },
+    {
+      "feature": "amenity",
+      "value": "caregiver",
+      "definition": "Models the presence and approximate point location of a service that provides caregiving services, especially to persons that experience disabilities."
+    },
+    {
+      "feature": "amenity",
+      "value": "carrental",
+      "definition": "A business that rents and leases motor vehicles. Businesses that rent trucks for moving and related purposes should be categorized under truck rentalservices."
+    },
+    {
+      "feature": "amenity",
+      "value": "cashier",
+      "definition": "Models the presence and approximate point location of a cashier operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "changemachine",
+      "definition": "Models the presence and approximate point location of a service that accepts large denominations of currency and returns an equal amount in smaller denominations."
+    },
+    {
+      "feature": "amenity",
+      "value": "checkin",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a collection of check-in operations."
+    },
+    {
+      "feature": "amenity",
+      "value": "checkin.desk",
+      "definition": "Models the presence and approximate point location or physical extent of furniture that supports one or more check-in desk operations."
+    },
+    {
+      "feature": "amenity",
+      "value": "checkin.desk.oversizebaggage",
+      "definition": "Models the presence and approximate point location of a check-in area, desk, or service where special or oversized baggage may be checked in."
+    },
+    {
+      "feature": "amenity",
+      "value": "checkin.desk.transfer",
+      "definition": "Models the presence and approximate point location of a manned transfer desk operation whose purpose is to facilitate a traveler's transfer to another outbound connection."
+    },
+    {
+      "feature": "amenity",
+      "value": "checkin.selfservice",
+      "definition": "Models the presence and approximate point location of furniture/equipment that supports full or semi-automated check-in operations."
+    },
+    {
+      "feature": "amenity",
+      "value": "childplayarea",
+      "definition": "Models the presence and approximate point location of a child's play area."
+    },
+    {
+      "feature": "amenity",
+      "value": "coinlocker"
+    },
+    {
+      "feature": "amenity",
+      "value": "copymachine",
+      "definition": "Models the presence and approximate point location of a copy machine service."
+    },
+    {
+      "feature": "amenity",
+      "value": "defibrillator",
+      "definition": "Models the presence and approximate point location of an Automated External Defibrillator (AED)."
+    },
+    {
+      "feature": "amenity",
+      "value": "drinkingfountain",
+      "definition": "Models the presence and approximate point location of drinking water."
+    },
+    {
+      "feature": "amenity",
+      "value": "eatingdrinking",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment that is used as a \"common\" area for dining."
+    },
+    {
+      "feature": "amenity",
+      "value": "elevator",
+      "definition": "Models the presence and approximate point location of one or more elevator that offers vertical traversal capabilities."
+    },
+    {
+      "feature": "amenity",
+      "value": "emergencyshelter",
+      "definition": "Models the presence and approximate point location of a room designed to provide shelter. e.g., protection from severe weather conditions."
+    },
+    {
+      "feature": "amenity",
+      "value": "entry",
+      "definition": "Models the presence and approximate point location of an entrance to a physical building."
+    },
+    {
+      "feature": "amenity",
+      "value": "escalator",
+      "definition": "Models the presence and physical extent of a single escalator that offers vertical traversal capabilities."
+    },
+    {
+      "feature": "amenity",
+      "value": "exhibit",
+      "definition": "Models the presence and approximate point location of \"...an object, work of art, activity, artifact or poster designed to demonstrate a concept or show an example.\", or the approximate thematic extent of an open or semi-enclosed environment containing an exhibit."
+    },
+    {
+      "feature": "amenity",
+      "value": "faregate",
+      "definition": "Models the presence and approximate point location of equipment that supports a fully automated or manned fare gate operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "faregate.oversized",
+      "definition": "Models the presence and approximate point location of a fare gate operation that is specifically designed for a pedestrian that requires an entrance whose width is greater than the \"standard\" fare gate."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay",
+      "definition": "Intramural sports or recreational fields usually found on college/university campus."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.americanfootball",
+      "definition": "Models the presence and approximate point location of an American football pitch."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.baseball",
+      "definition": "Models the presence and approximate point location of a baseball field."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.basketball",
+      "definition": "Models the presence and approximate point location of a basketball court."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.fieldhockey",
+      "definition": "Models the presence and approximate point location of a field hockey pitch."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.icehockey",
+      "definition": "Models the presence and approximate point location of an ice hockey rink."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.rugby",
+      "definition": "Models the presence and approximate point location of a rugby pitch."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.soccer",
+      "definition": "Models the presence and approximate point location of a soccer pitch."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.softball",
+      "definition": "Models the presence and approximate point location of a softball field."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.tennis",
+      "definition": "Models the presence and approximate point location of a tennis court."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.trackfield",
+      "definition": "Models the presence and approximate point location of a track and field arena."
+    },
+    {
+      "feature": "amenity",
+      "value": "fieldofplay.volleyball",
+      "definition": "Models the presence and approximate point location of a volleyball court."
+    },
+    {
+      "feature": "amenity",
+      "value": "firealarmpullstation",
+      "definition": "Models the presence and approximate point location of a fire protection device which, when activated, initiates an alarm on a fire alarm system."
+    },
+    {
+      "feature": "amenity",
+      "value": "fireextinguisher",
+      "definition": "Models the presence and approximate point location of a fire protection device."
+    },
+    {
+      "feature": "amenity",
+      "value": "firstaid",
+      "definition": "Models the presence and approximate point location of: A medical support operation or First Aid, or the physical extent of a space containing a medical support operation.."
+    },
+    {
+      "feature": "amenity",
+      "value": "fittingroom",
+      "definition": "Models the presence and approximate point location of one or more fitting room where a person may try on clothes or change clothes."
+    },
+    {
+      "feature": "amenity",
+      "value": "foodservice",
+      "definition": "Models the presence and approximate point location of a foodservice operation where a pedestrian can enjoy food and drink. The foodservice is offered by a foodservice company."
+    },
+    {
+      "feature": "amenity",
+      "value": "gatearea",
+      "definition": "Models the presence and approximate extent of an open or semi-enclosed environment containing a collection of thematically related gate holding areas."
+    },
+    {
+      "feature": "amenity",
+      "value": "groundtransportation",
+      "definition": "Models the presence and approximate point location of an area where a general set of ground transportation services exist."
+    },
+    {
+      "feature": "amenity",
+      "value": "guestservices",
+      "definition": "Models the presence and approximate point location of a guest service operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "handsanitizerstation",
+      "definition": "Models the presence and approximate point location of a hand sanitizer dispensing station."
+    },
+    {
+      "feature": "amenity",
+      "value": "healthscreening",
+      "definition": "Models the presence and approximate point location of personnel/equipment that supports a health screening operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "hoteling",
+      "definition": "Models the presence and approximate point location of: * A reservation-based unassigned work surface."
+    },
+    {
+      "feature": "amenity",
+      "value": "immigration",
+      "definition": "Models the presence and approximate point location of an immigration operation. (Also known as \"Passport Control.\")"
+    },
+    {
+      "feature": "amenity",
+      "value": "information",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the offering of information."
+    },
+    {
+      "feature": "amenity",
+      "value": "information.bid",
+      "definition": "Models the presence and approximate point location of a Baggage Information Display (BID) system that displays baggage claim information."
+    },
+    {
+      "feature": "amenity",
+      "value": "information.carrental",
+      "definition": "Models the presence and approximate point location of a manned desk or an automated information kiosk that: May exist in support of a particular brand name or is brand agnostic. Is not concerned with delivering other information types (e.g., tourism, hotel or airline information)."
+    },
+    {
+      "feature": "amenity",
+      "value": "information.hotel"
+    },
+    {
+      "feature": "amenity",
+      "value": "information.mufid",
+      "definition": "Models the presence and approximate point location of a Multiple User Flight Information Display system that displays flight information to passengers and patrons by destination city, airline, arrival and departure times, gate, and status of the flight (on-time, delayed, cancelled, boarding, or landed)."
+    },
+    {
+      "feature": "amenity",
+      "value": "information.mufid.arrivals",
+      "definition": "Models the presence and approximate point location of a Multiple User Flight Information Display system that displays flight information to passengers and patrons by arrival city, airline, arrival times, gate, and status of the flight (on-time, delayed, cancelled, boarding, or landed)."
+    },
+    {
+      "feature": "amenity",
+      "value": "information.mufid.departures",
+      "definition": "Models the presence and approximate point location of a Multiple User Flight Information Display system that displays flight information to passengers and patrons by departure city, airline, arrival times, gate, and status of the flight (on-time, delayed, cancelled, or boarding)."
+    },
+    {
+      "feature": "amenity",
+      "value": "information.transit",
+      "definition": "Models the presence and approximate point location of a manned desk or an automated information kiosk that: May exist in support of a particular brand name or is brand agnostic. Is not concerned with delivering other information types (e.g., tourism information, hotel.)."
+    },
+    {
+      "feature": "amenity",
+      "value": "landmark",
+      "definition": "Items in this category are spaces and places of significance and history."
+    },
+    {
+      "feature": "amenity",
+      "value": "library",
+      "definition": "A building or room where media is collected for people to read, borrow, and reference. Traditionally this is mostly books, but may also include other media too."
+    },
+    {
+      "feature": "amenity",
+      "value": "limo",
+      "definition": "A company that provides transportation services by limousines."
+    },
+    {
+      "feature": "amenity",
+      "value": "lostandfound",
+      "definition": "Models the presence and approximate point location of a service where a pedestrian may retrieve personal belongings."
+    },
+    {
+      "feature": "amenity",
+      "value": "mailbox",
+      "definition": "A physical box into which members of the public can deposit outgoing mail intended for collection by the agents of a country's postal service."
+    },
+    {
+      "feature": "amenity",
+      "value": "meditation",
+      "definition": "Facilities dedicated to the practice of meditation."
+    },
+    {
+      "feature": "amenity",
+      "value": "meetingpoint",
+      "definition": "Models the presence and approximate point location of a defined place where people can meet."
+    },
+    {
+      "feature": "amenity",
+      "value": "mobilityrescue",
+      "definition": "Models the presence and approximate point location of an assembly area where persons that experience disabilities may be assisted during an emergency event."
+    },
+    {
+      "feature": "amenity",
+      "value": "mothersroom",
+      "definition": "Models the presence and approximate point or physical extent of an enclosed space where a woman may breastfeed or use a breast pump in private."
+    },
+    {
+      "feature": "amenity",
+      "value": "movingwalkway",
+      "definition": "Models the presence and approximate point location or physical extent of one or more neighboring moving conveyor mechanism that transports pedestrians across a horizontal or inclined plane over a short to medium distance."
+    },
+    {
+      "feature": "amenity",
+      "value": "paidarea",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as a paid area."
+    },
+    {
+      "feature": "amenity",
+      "value": "parkandride",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is to host a Park & Ride service."
+    },
+    {
+      "feature": "amenity",
+      "value": "parking",
+      "definition": "Locations that provide office space to park vehicles, usually for a fee."
+    },
+    {
+      "feature": "amenity",
+      "value": "parking.bicycle",
+      "definition": "A business that offers parking spaces/services for bicycles only OR a large space specifically made for parking bicycles only, with or without a fee and may or may not have onsite pesonnel. OK to use for businesses that provide bike valet services as a core offering. Please note this should only be used for locations/businesses whose core competency is bike parking. Businesses that have bike racks at/outside of their space should not be categorized under Bike Parking (they should use the Bike Parking attribute, instead). Random bike racks located on public streets/areas are ineligible for a listing."
+    },
+    {
+      "feature": "amenity",
+      "value": "parking.compact",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the storage of vehicles defined in the automotive industry as being \"compact.\""
+    },
+    {
+      "feature": "amenity",
+      "value": "parking.ev",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the storage of electric vehicles."
+    },
+    {
+      "feature": "amenity",
+      "value": "parking.longterm",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment  whose intended purpose is the storage of vehicles for an extended period of time."
+    },
+    {
+      "feature": "amenity",
+      "value": "parking.motorcycle",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed of an environment whose intended purpose is the storage of motorcycles."
+    },
+    {
+      "feature": "amenity",
+      "value": "parking.shortterm",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the storage of vehicles for a short period of time."
+    },
+    {
+      "feature": "amenity",
+      "value": "parking.waitingarea",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is use by a person (and their vehicle) to wait for the arrival of another person(s)."
+    },
+    {
+      "feature": "amenity",
+      "value": "payphone"
+    },
+    {
+      "feature": "amenity",
+      "value": "pedestriancrossing",
+      "definition": "Models the presence and approximate point location of a pedestrian crossing."
+    },
+    {
+      "feature": "amenity",
+      "value": "peoplemover",
+      "definition": "Models the presence and approximate point location of a transit stop that is associated with a transportation system describable as an Automated People Mover."
+    },
+    {
+      "feature": "amenity",
+      "value": "phone",
+      "definition": "Models the presence and approximate point location of a telephone or a \"bank\" of telephones."
+    },
+    {
+      "feature": "amenity",
+      "value": "phone.emergency",
+      "definition": "Models the presence and approximate point location of an emergency telephone service."
+    },
+    {
+      "feature": "amenity",
+      "value": "photobooth"
+    },
+    {
+      "feature": "amenity",
+      "value": "platform",
+      "definition": "Models the presence and approximate point location of an individually named (or numbered) train platform."
+    },
+    {
+      "feature": "amenity",
+      "value": "police",
+      "definition": "Models the presence and approximate point location of a police sub-station, office or desk that is permanently staffed by police."
+    },
+    {
+      "feature": "amenity",
+      "value": "powerchargingstation"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom",
+      "definition": "Models the presence and approximate point location of a place for religious prayer or meditation. Inter-faith (non-denominational) is assumed."
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.buddhism"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.christianity"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.hinduism"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.islam"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.islam.female"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.islam.male"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.judaism"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.shintoism"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.sikh"
+    },
+    {
+      "feature": "amenity",
+      "value": "prayerroom.taoic"
+    },
+    {
+      "feature": "amenity",
+      "value": "privatelounge",
+      "definition": "Models the presence and physical extent of an enclosed space that is made available to authorized pedestrians."
+    },
+    {
+      "feature": "amenity",
+      "value": "productreturn",
+      "definition": "Models the presence and approximate point location of a product return service operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "rail.muni",
+      "definition": "Models the presence and approximate point location of one or more rail stop that is serviced by a local transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "rail.national",
+      "definition": "Models the presence and approximate point location of one or more rail stop that is serviced by a national transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "ramp",
+      "definition": "Models the presence and approximate point location or physical extent of an incline plane."
+    },
+    {
+      "feature": "amenity",
+      "value": "reception.desk",
+      "definition": "Models the presence and approximate point location of a reception desk."
+    },
+    {
+      "feature": "amenity",
+      "value": "recreation",
+      "definition": "Business or location related to recreational activities."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom",
+      "definition": "Models the presence and approximate point location of one or more neighboring spaces, or the physical extent of a single enclosed space, containing bathroom facilities."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.family",
+      "definition": "A bathroom intended for family use"
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.female",
+      "definition": "A bathroom intended for female use"
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.female.wheelchair",
+      "definition": "Models the presence and approximate point location of a female bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.male",
+      "definition": "A bathroom intended for male use"
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.male.wheelchair",
+      "definition": "Models the presence and approximate point location of a male bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.transgender",
+      "definition": "Models the presence and approximate point location of one or more neighboring spaces, or the physical extent of a single space, containing bathroom facilities that are intended for use by a person that identifies themselves as transgender."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.transgender.wheelchair",
+      "definition": "Models the presence and approximate point location of a transgender bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.unisex",
+      "definition": "Models the presence and approximate point location of one or more neighboring spaces, or the physical extent of a single space, containing bathroom facilities that are intended for use by any person."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.unisex.wheelchair",
+      "definition": "Models the presence and approximate point location of a unisex bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "amenity",
+      "value": "restroom.wheelchair",
+      "definition": "Dedicated restroom designed to be accessible for those with physical disabilities."
+    },
+    {
+      "feature": "amenity",
+      "value": "rideshare",
+      "definition": "Business or service that facilitates ride sharing or carpooling allowing multiple riders to share a car trip."
+    },
+    {
+      "feature": "amenity",
+      "value": "seat",
+      "definition": "Models the presence and approximate point location of a seat."
+    },
+    {
+      "feature": "amenity",
+      "value": "seating",
+      "definition": "models the presence and location of an open or semi-enclosed seating environment."
+    },
+    {
+      "feature": "amenity",
+      "value": "security",
+      "definition": "A business or organization who can be hired for private security"
+    },
+    {
+      "feature": "amenity",
+      "value": "security.checkpoint",
+      "definition": "Models the presence and approximate point location of personnel/equipment that supports a security operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "security.inspection",
+      "definition": "Models the presence and approximate point location of an inspection operation. Customs Inspection (International Travel) National/Federal Inspection (Domestic Travel)"
+    },
+    {
+      "feature": "amenity",
+      "value": "service",
+      "definition": "Should be used to model the presence and approximate point location, or approximate thematic extent of an open or semi-enclosed area, of an service operation that cannot be classified using any other \"service\" category in the hierarchy."
+    },
+    {
+      "feature": "amenity",
+      "value": "shower",
+      "definition": "Models the presence and approximate point location of one or more neighboring shower facility and adjoining locker/changing area, or the physical extent of an enclosed space that provides shower facilities and adjoining locker/changing area."
+    },
+    {
+      "feature": "amenity",
+      "value": "shuttle",
+      "definition": "Models the presence and approximate point location of one or more bus stop that is serviced by a private enterprise, not a national or local transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "sleepbox",
+      "definition": "Models the presence and approximate point location of one or more service that offers a bed and an associated set of facilities in a limited space."
+    },
+    {
+      "feature": "amenity",
+      "value": "smokingarea",
+      "definition": "Models the presence and approximate point location, or physical extent of a space containing a smoking area or facility."
+    },
+    {
+      "feature": "amenity",
+      "value": "stairs",
+      "definition": "Models the presence and approximate point location of one or more neighboring staircase, or the physical extent of a single staircase, that supports vertical traversal to a physically different floor that may or may not be eligible for capture as a Level."
+    },
+    {
+      "feature": "amenity",
+      "value": "storage",
+      "definition": "Models the presence and approximate point location of a storage facility."
+    },
+    {
+      "feature": "amenity",
+      "value": "strollerrental",
+      "definition": "Models the presence and approximate point location of a stroller rental service."
+    },
+    {
+      "feature": "amenity",
+      "value": "studentadmissions",
+      "definition": "Models the presence and approximate point location of a student admissions operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "studentservices",
+      "definition": "Models the presence and approximate point location of a student services operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "swimmingpool",
+      "definition": "Facilities where one can swim in a swimming pool."
+    },
+    {
+      "feature": "amenity",
+      "value": "swimmingpool.children"
+    },
+    {
+      "feature": "amenity",
+      "value": "swimmingpool.family"
+    },
+    {
+      "feature": "amenity",
+      "value": "taxi",
+      "definition": "A vehicle providing individualized transportation a location specified by the customer."
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing",
+      "definition": "Models the presence and approximate point location of an automated or manned ticketing operation, or the approximate thematic extent of an area containing ticketing operations and services."
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.airline",
+      "definition": "Models the presence and approximate point location of a manned airline ticketing operation."
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.bus"
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.bus.muni",
+      "definition": "Models the presence and approximate point location of an automated or manned bus ticketing operation that is provided by a local transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.bus.national",
+      "definition": "Models the presence and approximate point location of an automated or manned bus ticketing operation that is provided by a national transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.rail"
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.rail.muni",
+      "definition": "Models the presence and approximate point location of an automated or manned rail ticketing operation that is provided by a national transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.rail.national",
+      "definition": "Models the presence and approximate point location of an automated or manned rail ticketing operation that is provided by a national transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "ticketing.shuttle",
+      "definition": "Models the presence and approximate point location of an automated or manned private ticketing operation that is provided by a private enterprise, not a national or local transit authority."
+    },
+    {
+      "feature": "amenity",
+      "value": "traintrack",
+      "definition": "Models the presence and approximate point location of an individually named (or numbered) train track or physical portion of a train platform."
+    },
+    {
+      "feature": "amenity",
+      "value": "transit",
+      "definition": "Describes a physical structure whose sole operational purpose is to provide transportation services."
+    },
+    {
+      "feature": "amenity",
+      "value": "unspecified",
+      "definition": "Models the presence and approximate point location of a physical object or service that cannot be classified using any other category, or whose utilization is unknown."
+    },
+    {
+      "feature": "amenity",
+      "value": "valet",
+      "definition": "Models the presence and approximate point location of a valet parking service."
+    },
+    {
+      "feature": "amenity",
+      "value": "vendingmachine",
+      "definition": "Automated machine that provides items using a payment system. Please use shopping.vendingmachine.refreshments for food related machines."
+    },
+    {
+      "feature": "amenity",
+      "value": "vendingmachine.trainticket",
+      "definition": "Models the presence and approximate point location of an automated system that vends train tickets."
+    },
+    {
+      "feature": "amenity",
+      "value": "wheelchairassist",
+      "definition": "Models the presence and approximate point location of a wheelchair assistance service."
+    },
+    {
+      "feature": "amenity",
+      "value": "wifi",
+      "definition": "Models the presence and approximate point location of a designated zone/area/\"hot spot\" where Wi-Fi service is available."
+    },
+    {
+      "feature": "amenity",
+      "value": "yoga",
+      "definition": "Facilities providing space and instruction for the practice of yoga. Do not use for businesses not offering yoga as their core instruction (e.g. a gym offering yoga once a week should not receive this category)."
+    },
+    {
+      "feature": "building",
+      "value": "parking",
+      "definition": "Locations that provide office space to park vehicles, usually for a fee."
+    },
+    {
+      "feature": "building",
+      "value": "transit",
+      "definition": "Describes a physical structure whose sole operational purpose is to provide transportation services."
+    },
+    {
+      "feature": "building",
+      "value": "transit.bus",
+      "definition": "Describes a physical structure whose sole operational purpose is to provide bus transportation services."
+    },
+    {
+      "feature": "building",
+      "value": "transit.train",
+      "definition": "Describes a physical structure whose sole operational purpose is to provide train transportation services."
+    },
+    {
+      "feature": "building",
+      "value": "unspecified",
+      "definition": "Models the presence and approximate point location of a physical object or service that cannot be classified using any other category, or whose utilization is unknown."
+    },
+    {
+      "feature": "door",
+      "value": "door"
+    },
+    {
+      "feature": "door",
+      "value": "movablepartition",
+      "definition": "Models a partition wall that may open to join two or more rooms into one large floor area."
+    },
+    {
+      "feature": "door",
+      "value": "open",
+      "definition": "Models a doorway that is without a physical barrier. (It has no physical door.)"
+    },
+    {
+      "feature": "door",
+      "value": "revolving",
+      "definition": "Models a physical door that rotates."
+    },
+    {
+      "feature": "door",
+      "value": "shutter",
+      "definition": "Models a physical door that rolls open and closed."
+    },
+    {
+      "feature": "door",
+      "value": "sliding",
+      "definition": "Models a physical door that slides or glides open and closed."
+    },
+    {
+      "feature": "door",
+      "value": "swinging",
+      "definition": "Models a physical door that swings open and closed."
+    },
+    {
+      "feature": "door",
+      "value": "turnstile"
+    },
+    {
+      "feature": "door",
+      "value": "turnstile.fullheight"
+    },
+    {
+      "feature": "door",
+      "value": "turnstile.waistheight"
+    },
+    {
+      "feature": "door",
+      "value": "unspecified",
+      "definition": "Models the presence and approximate point location of a physical object or service that cannot be classified using any other category, or whose utilization is unknown."
+    },
+    {
+      "feature": "door-material",
+      "value": "gate"
+    },
+    {
+      "feature": "door-material",
+      "value": "glass"
+    },
+    {
+      "feature": "door-material",
+      "value": "metal"
+    },
+    {
+      "feature": "door-material",
+      "value": "wood"
+    },
+    {
+      "feature": "fixture",
+      "value": "baggagecarousel",
+      "definition": "Models the presence and approximate point location of an individual Baggage Carousel."
+    },
+    {
+      "feature": "fixture",
+      "value": "boardinggate.desk",
+      "definition": "Models the presence and physical extent of furniture that supports a boarding gate operation."
+    },
+    {
+      "feature": "fixture",
+      "value": "checkin.desk",
+      "definition": "Models the presence and approximate point location or physical extent of furniture that supports one or more check-in desk operations."
+    },
+    {
+      "feature": "fixture",
+      "value": "checkin.kiosk",
+      "definition": "Models the presence and physical extent of an automated or semi-automated check-in and/or ticketing kiosk operation."
+    },
+    {
+      "feature": "fixture",
+      "value": "desk",
+      "definition": "Models the presence and physical extent of an individual or shared work surface or desk."
+    },
+    {
+      "feature": "fixture",
+      "value": "equipment",
+      "definition": "Models the presence and physical extent of capital equipment that supports an operation."
+    },
+    {
+      "feature": "fixture",
+      "value": "furniture",
+      "definition": "A shop that sells furniture, such as tables, chairs, couches, desks. The items sold are of a more general spread of purpose types, not to be confused with specialized stores like mattress stores or outdoor furniture stores."
+    },
+    {
+      "feature": "fixture",
+      "value": "immigration.desk",
+      "definition": "Models the presence and physical extent of furniture that supports immigration (passport control) operations."
+    },
+    {
+      "feature": "fixture",
+      "value": "inspection.desk",
+      "definition": "Models the presence and physical extent of furniture that supports an inspection or security operation."
+    },
+    {
+      "feature": "fixture",
+      "value": "obstruction",
+      "definition": "Models the presence and physical extent of a physical, non-traversable object."
+    },
+    {
+      "feature": "fixture",
+      "value": "securityequipment",
+      "definition": "Models the presence and physical extent of capital equipment that supports a security operation."
+    },
+    {
+      "feature": "fixture",
+      "value": "stage"
+    },
+    {
+      "feature": "fixture",
+      "value": "vegetation",
+      "definition": "Models the presence and physical extent of a natural or artificial vegetation feature or an open or semi-enclosed vegetative area that may or may not be prohibited from being used as a pedestrian pathway."
+    },
+    {
+      "feature": "fixture",
+      "value": "wall",
+      "definition": "Models the presence and physical extent of a standalone barrier that is permanent, temporary or moveable."
+    },
+    {
+      "feature": "fixture",
+      "value": "water",
+      "definition": "Models the presence and physical extent of a natural or artificial water feature."
+    },
+    {
+      "feature": "footprint",
+      "value": "aerial",
+      "definition": "Models the referenced Building as \"...represented as the shadow projected downward from an overhead light at infinity.\""
+    },
+    {
+      "feature": "footprint",
+      "value": "ground",
+      "definition": "Models the referenced Building using the actual physical extent at ground-level."
+    },
+    {
+      "feature": "footprint",
+      "value": "subterranean",
+      "definition": "Derived from the maximum extent of all floors, modeled as one or more Level, that exist below ground-level."
+    },
+    {
+      "feature": "geofence",
+      "value": "concourse",
+      "definition": "A large open area inside or in front of a public building, as in an airport or train station."
+    },
+    {
+      "feature": "geofence",
+      "value": "geofence",
+      "definition": "A geofence is a virtual boundary. The purpose of the geofence is to attribute applicable features, that fall within its boundary, with characteristics held by the geofence itself. A geofence can support: Location \"awareness\" among features. Location-based services. Query and find by location functionality."
+    },
+    {
+      "feature": "geofence",
+      "value": "paidarea",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as a paid area."
+    },
+    {
+      "feature": "geofence",
+      "value": "platform",
+      "definition": "Models the presence and approximate point location of an individually named (or numbered) train platform."
+    },
+    {
+      "feature": "geofence",
+      "value": "postsecurity",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as post-security."
+    },
+    {
+      "feature": "geofence",
+      "value": "presecurity",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as pre-security."
+    },
+    {
+      "feature": "geofence",
+      "value": "terminal",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as a terminal."
+    },
+    {
+      "feature": "geofence",
+      "value": "underconstruction",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as under construction."
+    },
+    {
+      "feature": "level",
+      "value": "arrivals",
+      "definition": "Models the presence and physical extent of a floor of a physical building whose intended purpose is to support the movement of pedestrians that are arriving from a location."
+    },
+    {
+      "feature": "level",
+      "value": "arrivals.domestic",
+      "definition": "Models the presence and physical extent of a floor of a physical building whose intended purpose is to support the movement of pedestrians that are arriving from a domestic location."
+    },
+    {
+      "feature": "level",
+      "value": "arrivals.intl",
+      "definition": "Models the presence and physical extent of a floor of a physical building whose intended purpose is to support the movement of pedestrians that are arriving from an international location."
+    },
+    {
+      "feature": "level",
+      "value": "departures",
+      "definition": "Models the presence and physical extent of a floor of a physical building whose intended purpose is to support the movement of pedestrians that are departing to a destination."
+    },
+    {
+      "feature": "level",
+      "value": "departures.domestic",
+      "definition": "Models the presence and physical extent of a floor of a physical building whose intended purpose is to support the movement of pedestrians that are departing to a domestic destination."
+    },
+    {
+      "feature": "level",
+      "value": "departures.intl",
+      "definition": "Models the presence and physical extent of a floor of a physical building whose intended purpose is to support the movement of pedestrians that are departing to an international destination."
+    },
+    {
+      "feature": "level",
+      "value": "parking",
+      "definition": "Locations that provide office space to park vehicles, usually for a fee."
+    },
+    {
+      "feature": "level",
+      "value": "transit",
+      "definition": "Describes a physical structure whose sole operational purpose is to provide transportation services."
+    },
+    {
+      "feature": "level",
+      "value": "unspecified",
+      "definition": "Models the presence and approximate point location of a physical object or service that cannot be classified using any other category, or whose utilization is unknown."
+    },
+    {
+      "feature": "occupant",
+      "value": "3dprinting",
+      "definition": "A business that provides 3D printing services. 3D printers synthesize three-dimensional object by adding successive layers of material under the control of a computer."
+    },
+    {
+      "feature": "occupant",
+      "value": "acai",
+      "definition": "A business that specializes in acai bowls, a thick smoothie made out of frozen and mashed acai berries (acai palm) and topped with various ingredients, most commonly oatmeal/granola, fruit, coconut flakes, honey, syrup, peanut butter, almonds, and hemp seeds. Although acai bowls are usually sweet, there are also savory versions containing shrimp or dried fish and tapioca (typically found in Northern Brazil)."
+    },
+    {
+      "feature": "occupant",
+      "value": "accessories"
+    },
+    {
+      "feature": "occupant",
+      "value": "accounting",
+      "definition": "A person or business with expertise in financial accounts"
+    },
+    {
+      "feature": "occupant",
+      "value": "acnetreatment",
+      "definition": "A business or individual specializing in treating acne (whiteheads, blackheads, or pimples), which often includes laser treatments, medications, targeted facials, and diet management. (Note: this should not be used for products for treating acne as they are generally not eligible for a Yelp listing.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "acupuncture",
+      "definition": "A business or clinic with expertise in the alternative medicine of acupuncture. Originating within traditional Chinese medicine, acupuncture is a technique of inserting thin needles into the body (and occasionally the application of heat, pressure, or laser light) at acupuncture points."
+    },
+    {
+      "feature": "occupant",
+      "value": "adoptionservices",
+      "definition": "An organization or business that helps find children for adults to adopt. For Pets please use pets.petadoption."
+    },
+    {
+      "feature": "occupant",
+      "value": "adulteducation",
+      "definition": "Schools specializing in programs for adults, both degree and non-degree, at the university-level or technical-training level."
+    },
+    {
+      "feature": "occupant",
+      "value": "adultentertainment",
+      "definition": "A venue with entertainment usually considered of an adult nature, typically sexual. This include places like strip clubs, and legal sex work."
+    },
+    {
+      "feature": "occupant",
+      "value": "adultstore",
+      "definition": "A business specializing in the sale of adult themed items"
+    },
+    {
+      "feature": "occupant",
+      "value": "advertising",
+      "definition": "A person or business with expertise in advertising."
+    },
+    {
+      "feature": "occupant",
+      "value": "advisoryservices",
+      "definition": "Businesses or individuals specializing in the management of clients' financial investments and/or assets, providing investment advice, and offering financial planning services."
+    },
+    {
+      "feature": "occupant",
+      "value": "afghani",
+      "definition": "An establishment specializing in Afgan cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "african",
+      "definition": "An establishment specializing in African cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "agritourism",
+      "definition": "Any agriculturally based operation or activity that brings visitors to a farm or ranch."
+    },
+    {
+      "feature": "occupant",
+      "value": "airfield",
+      "definition": "An open field designated for the taking off and landing of aircraft, but which, unlike an airport, does not necessarily have terminals or paved runways."
+    },
+    {
+      "feature": "occupant",
+      "value": "airline",
+      "definition": "A company that provides the service of air travel including the planes and pilots."
+    },
+    {
+      "feature": "occupant",
+      "value": "airport.regional",
+      "definition": "A facility for the landing, takeoff, shelter, supply, and repair of aircraft, especially one used for receiving or discharging passengers and cargo at regularly scheduled times that handles only domestic flights—flights within the same country."
+    },
+    {
+      "feature": "occupant",
+      "value": "airportloungebar",
+      "definition": "A lounge space inside an airport restricted to customers of specific airlines. Usually offering greater comfort and service than the regular section of the airport."
+    },
+    {
+      "feature": "occupant",
+      "value": "airportshuttle",
+      "definition": "A van or bus providing travel to and from airports."
+    },
+    {
+      "feature": "occupant",
+      "value": "airsoft",
+      "definition": "A facility where airsoft, a military simulation sport where players participate in mock combat with authentic military-style weapons and tactics, is played. The airsoft guns used are full scale replicas of real world weapons (not to be confused with paintball, which uses special paint marker/guns)."
+    },
+    {
+      "feature": "occupant",
+      "value": "allergies",
+      "definition": "Doctors specializing in diagnosing and treating allergies."
+    },
+    {
+      "feature": "occupant",
+      "value": "alternativemedicine",
+      "definition": "An establishment offering treatment which falls in any of a range of medical therapies that are not regarded as orthodox by the medical profession, such as herbalism, homeopathy, and acupuncture."
+    },
+    {
+      "feature": "occupant",
+      "value": "american.modern",
+      "definition": "An establishment specializing in modern American cuisine, typically more fine dining experience."
+    },
+    {
+      "feature": "occupant",
+      "value": "amusementpark",
+      "definition": "Commercially operated parks featuring roller coasters, shooting galleries, merry-go-rounds, and refreshment stands. For Kids, please use kids_activities."
+    },
+    {
+      "feature": "occupant",
+      "value": "amusementpark.ride",
+      "definition": "An attraction at an amusement park or carnival type event."
+    },
+    {
+      "feature": "occupant",
+      "value": "animalshelter",
+      "definition": "An organization that cares for, treats, houses and re-homes animals that have either been rescued from the street or handed in by the public"
+    },
+    {
+      "feature": "occupant",
+      "value": "antiques",
+      "definition": "A business specializing in the sale of antique goods"
+    },
+    {
+      "feature": "occupant",
+      "value": "apmstop",
+      "definition": "A transit stop for an Automated People Mover (APM) which generally connects multiple buildings or terminals within an airport or other large venue; Eg airtrains, skyrails, etc"
+    },
+    {
+      "feature": "occupant",
+      "value": "appliances",
+      "definition": "A retailer selling consumer grade items for household consumption. Things like white goods, Televisions, electronics, kettles, sewing machines, vacuum cleaners, stereos, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "arabian",
+      "definition": "An establishment specializing in Arabian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "arabian.pizza",
+      "definition": "A restaurant specializing in Arab style flatbread generally topped with tomato sauce and cheese."
+    },
+    {
+      "feature": "occupant",
+      "value": "arcade",
+      "definition": "Facilities offering arcade games."
+    },
+    {
+      "feature": "occupant",
+      "value": "archery",
+      "definition": "Locations or facilities where archery is played, a sport played using a bow and arrow."
+    },
+    {
+      "feature": "occupant",
+      "value": "architecture",
+      "definition": "A person or business with expertise in architecture"
+    },
+    {
+      "feature": "occupant",
+      "value": "argentine",
+      "definition": "An establishment specializing in Argentine cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "armenian",
+      "definition": "An establishment specializing in Armenian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "artgallery",
+      "definition": "Facilities dedicated to the sale of visual art, e.g. paintings, sculptures, and photographs. Includes art museums, in conjunction with the museum category."
+    },
+    {
+      "feature": "occupant",
+      "value": "artinstruction",
+      "definition": "Businesses that are less formal than art schools, specializing in art instruction for generally recreational purposes."
+    },
+    {
+      "feature": "occupant",
+      "value": "arts.entertainment"
+    },
+    {
+      "feature": "occupant",
+      "value": "artsandcrafts",
+      "definition": "A business specializing in the sale of items and materials associated with creating art and craft hobbies like painting, sculpting, drawing, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "artschool",
+      "definition": "Educational institutions specializing in instruction in the visual arts. Not to be confused with Art Classes, or schools offering a degree or certification."
+    },
+    {
+      "feature": "occupant",
+      "value": "artstudio",
+      "definition": "A workshop or studio where a professional artist, artisan, or designer creates. Traditionally, ateliers were for fine and decorative arts, but today they can be used for various forms of art (ceramics, painting, photography, knitting, chocolate-making, glass and jewelry design, etc.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "artstudio.rental",
+      "definition": "Studios and spaces available to rent for the production of art."
+    },
+    {
+      "feature": "occupant",
+      "value": "artsupplies",
+      "definition": "A business specializing in the sale of supplies for creating art."
+    },
+    {
+      "feature": "occupant",
+      "value": "asianfusion",
+      "definition": "An establishment specializing in food that is a combination of traditional Asian styles and flavors with modern techniques and foreign influences."
+    },
+    {
+      "feature": "occupant",
+      "value": "astrologist",
+      "definition": "A person who uses astrology to tell others about their character or to predict their future."
+    },
+    {
+      "feature": "occupant",
+      "value": "asturian",
+      "definition": "A restaurant specializing in the regional cuisine of Asturia."
+    },
+    {
+      "feature": "occupant",
+      "value": "atm"
+    },
+    {
+      "feature": "occupant",
+      "value": "atm.cryptocurrency",
+      "definition": "ATM specifically used for cryptocurrencies like Bitcoin."
+    },
+    {
+      "feature": "occupant",
+      "value": "audiovideoequipment",
+      "definition": "A business specializing in high quality audio equipment."
+    },
+    {
+      "feature": "occupant",
+      "value": "auditory",
+      "definition": "Doctors specializing in the diagnosis and treatment of hearing and balance problems, and other related disorders."
+    },
+    {
+      "feature": "occupant",
+      "value": "australian",
+      "definition": "An establishment specializing in Australian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "australian.modern",
+      "definition": "A restaurant specializing in contemporary Australian cuisine which may include fusions with other culinary traditions."
+    },
+    {
+      "feature": "occupant",
+      "value": "austrian",
+      "definition": "An establishment specializing in Austrian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "austrian.schnitzel",
+      "definition": "A restaurant that primarily specializes in schnitzel, a deep-fried breaded cutlet of meat, typically of veal, mutton, chicken, beef, turkey, reindeer, or pork."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.accessibilityequipment",
+      "definition": "Businesses specializing in the sale of car equipment, such as van lifts or wheelchairs, designed for the disabled."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.bodyshop",
+      "definition": "Auto repair businesses that specialize in cosmetic repairs (e.g. fixing dents, painting, replacing bumpers). For businesses that specialize in window tinting, use autoglass."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.carbuyer",
+      "definition": "Services specializing in the purchase of used cars from private sellers."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.carshare",
+      "definition": "Businesses that offer vehicles for short term use, such as Zipcar, usually by the hour from various locations in metropolitan areas."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.carwash",
+      "definition": "Businesses specializing in the washing of cars, usually with mechanical brushes and sometimes focusing on the interior as well. Do not use for auto detailing."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.dealer.boat",
+      "definition": "Businesses that sell new or used boats, as well as boat parts."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.dealer.car",
+      "definition": "Retail businesses that sell new or used cars, often showcased in large lots. Do not use for businesses with auto repair or body shops attached."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.dealer.motorcycle",
+      "definition": "Businesses that sell motorcycles, mopeds, or scooters."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.dealer.rv",
+      "definition": "Businesses that sell motorsport vehicles such as ATVs, jet skis, and snowmobiles."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.dentrepair.mobile",
+      "definition": "Mobile businesses that provide on-site repair for automobile dents."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.detailing",
+      "definition": "Services providing cleaning, polishing, and washing of automobiles to a show-quality level of detail."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.electric",
+      "definition": "A business specializing in the repair and troubleshooting of vehicles electrical system"
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.evcharge"
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.evcharge.dcfast",
+      "definition": "An electric vehicle charging type that supersedes Level 1 and Level 2 charging stations, and are designed to charge electric vehicles quickly"
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.evcharge.tesla",
+      "definition": "An electric vehicle charging type that only supports charging for Tesla vehicles."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.glass",
+      "definition": "Businesses specializing in car window repairs, tinting, and installation."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.oilchange",
+      "definition": "Businesses specializing in oil change services for cars. Do not use for auto repair."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.parts",
+      "definition": "Businesses that sell auto parts and supplies, and may also provide installation assistance, but not repair."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.repair",
+      "definition": "Businesses that repair mechanical problems in automobile engines."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.repair.transmission",
+      "definition": "Car repair shops specializing in the repair of transmissions."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.repair.wheelrim",
+      "definition": "Businesses that repair the wheels of rims of automobiles."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.repair.windshield",
+      "definition": "Businesses that specialize in the repair or installation of windshields."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.servicestation",
+      "definition": "Businesses specializing in the sale of fuel and minor repair services for automobiles. This category includes businesses offering light refreshments such as snack foods and drinks."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.shipping",
+      "definition": "Businesses specializing in the facilitation of transport vehicles."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.stereoinstallation",
+      "definition": "Businesses specializing in audio system installations for cars, including speakres, amplifiers, and wiring."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.tires",
+      "definition": "Businesses specializing in the sale, repair, and servicing of tires."
+    },
+    {
+      "feature": "occupant",
+      "value": "auto.upholstery"
+    },
+    {
+      "feature": "occupant",
+      "value": "automotive"
+    },
+    {
+      "feature": "occupant",
+      "value": "autopartssupplies"
+    },
+    {
+      "feature": "occupant",
+      "value": "babyclothesandsupplies",
+      "definition": "A business specializing in the sale of infant related accessories, like cots and car seats, clothing, strollers, travel bags and furniture."
+    },
+    {
+      "feature": "occupant",
+      "value": "bagels",
+      "definition": "Shops that sell bagels, primarily."
+    },
+    {
+      "feature": "occupant",
+      "value": "bakedgoods",
+      "definition": "Shops that sell baked goods, e.g. bread, cake, and pastries."
+    },
+    {
+      "feature": "occupant",
+      "value": "ballonservices",
+      "definition": "An establishment offering balloon services"
+    },
+    {
+      "feature": "occupant",
+      "value": "bangladeshi",
+      "definition": "An establishment specializing in Bangladeshi cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "bank",
+      "definition": "Businesses in which money is invested and/or protected for a client."
+    },
+    {
+      "feature": "occupant",
+      "value": "bar",
+      "definition": "A venue where their primary business is serving alcohol to the public. Food may also be served but is not the main focus."
+    },
+    {
+      "feature": "occupant",
+      "value": "barbecue",
+      "definition": "An establishment specializing in food cooked on a barbecue or grill."
+    },
+    {
+      "feature": "occupant",
+      "value": "barber",
+      "definition": "Individuals or businesses that specialize in the service of haircuts or facial shaving for men."
+    },
+    {
+      "feature": "occupant",
+      "value": "barfood",
+      "definition": "A restaurant serving food characteristic of pubs and bars such as burgers or fish and chips."
+    },
+    {
+      "feature": "occupant",
+      "value": "barreclass",
+      "definition": "Group classes involving an individual teacher instructing participants in workouts on a ballet barre, focusing on small movements designed to tone muscles on the arms, abdomen, gluteal muscles and thighs."
+    },
+    {
+      "feature": "occupant",
+      "value": "baseballfield",
+      "definition": "Locations or facilities where the sport of baseball is played."
+    },
+    {
+      "feature": "occupant",
+      "value": "bathingarea",
+      "definition": "An establishment that is equipped for recreational swimming or the washing of the body."
+    },
+    {
+      "feature": "occupant",
+      "value": "batteries",
+      "definition": "A business specializing in the sale of batteries"
+    },
+    {
+      "feature": "occupant",
+      "value": "battingcages",
+      "definition": "Facilities where one can practice hitting baseballs fired from a machine."
+    },
+    {
+      "feature": "occupant",
+      "value": "beach",
+      "definition": "Beach areas where people sunbathe and swim. Do not use for other activities located on beaches."
+    },
+    {
+      "feature": "occupant",
+      "value": "beautysalon",
+      "definition": "Businesses specializing in manicures, pedicures, and nail enhancement services."
+    },
+    {
+      "feature": "occupant",
+      "value": "beautyspas"
+    },
+    {
+      "feature": "occupant",
+      "value": "bedbreakfast",
+      "definition": "Typically a small lodging or house where overnight rooms are available and breakfast is provided. As usually private or family homes, they should not be used in conjunction with the hotel or resort category."
+    },
+    {
+      "feature": "occupant",
+      "value": "beerbar",
+      "definition": "A venue where their primary business is serving beer to the public."
+    },
+    {
+      "feature": "occupant",
+      "value": "beergarden",
+      "definition": "An outdoor area in which beer and local food are served, typically at shared tables."
+    },
+    {
+      "feature": "occupant",
+      "value": "beerhall",
+      "definition": "A large pub that specializing in beer."
+    },
+    {
+      "feature": "occupant",
+      "value": "beerwineandspirits",
+      "definition": "Retail shops selling beer, wine, and spirits."
+    },
+    {
+      "feature": "occupant",
+      "value": "beerwinespirits"
+    },
+    {
+      "feature": "occupant",
+      "value": "beisl",
+      "definition": "A traditional Austrian restaurant."
+    },
+    {
+      "feature": "occupant",
+      "value": "belgian",
+      "definition": "An establishment specializing in Belgian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "belgian.flemish",
+      "definition": "A restaurant specializing in Flemish cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "bengali",
+      "definition": "A food establishment specializing in cuisine from Bengal, a region in the eastern part of the Indian subcontinent, which is now divided between Bangladesh and West Bengal. Bengali cuisine consists primarily of fish, vegetables and lentils served with rice and is known for its subtle yet sometimes fiery flavors."
+    },
+    {
+      "feature": "occupant",
+      "value": "beveragestore",
+      "definition": "A business that sells alcoholic and non-alcoholic beverages."
+    },
+    {
+      "feature": "occupant",
+      "value": "bicycle.repair",
+      "definition": "A business that offers repair and maintenance services for bicycles."
+    },
+    {
+      "feature": "occupant",
+      "value": "bicyclerental",
+      "definition": "Businesses offering the temporary use of bicycles for a fee. For Party Bike Rentalservicess, use eventservices.partybikerentalservicess."
+    },
+    {
+      "feature": "occupant",
+      "value": "bicycleshop",
+      "definition": "A business that sells bicycles, accessories and components and offers repair services."
+    },
+    {
+      "feature": "occupant",
+      "value": "bikesandequipment",
+      "definition": "A store offering bicycles and cycling equipment such as helmets and apparel."
+    },
+    {
+      "feature": "occupant",
+      "value": "billingservices",
+      "definition": "A business or individual specializing in submitting and following up on medical claims with health insurance companies in order to receive payment for services rendered by a healthcare provider. This category is intended for medical billing services."
+    },
+    {
+      "feature": "occupant",
+      "value": "bingo",
+      "definition": "Facilities where groups of people gather to play bingo."
+    },
+    {
+      "feature": "occupant",
+      "value": "biryani",
+      "definition": "A restaurant specializing in Biryani, defined by the region of its origin. Popular variants of biryani in include the Hyderabadi Biryani, Chettinad Biryani, Malabar Biryani and the Awadhi Biryani."
+    },
+    {
+      "feature": "occupant",
+      "value": "bistro",
+      "definition": "A small restaurant, serving moderately priced simple meals in a modest setting."
+    },
+    {
+      "feature": "occupant",
+      "value": "blacksea",
+      "definition": "A restaurant specializing in the cuisine of the Black Sea region."
+    },
+    {
+      "feature": "occupant",
+      "value": "blinds",
+      "definition": "A business that provides and services the blinds and shades of windows."
+    },
+    {
+      "feature": "occupant",
+      "value": "blooddonation",
+      "definition": "An organization where individuals can donate blood or plasma. Can also be used for blood banks."
+    },
+    {
+      "feature": "occupant",
+      "value": "blooddonationcenter",
+      "definition": "A facility where a person voluntarily has his blood drawn which is used for transfusions and/or made into biopharmaceutical medications. The category includes permanent facilities as well as mobile sites such as “Bloodmobiles”."
+    },
+    {
+      "feature": "occupant",
+      "value": "bodycontouring",
+      "definition": "An establishment which specializes in procedures that alter the shape of the human body, such as procedures that eliminate or reduce excess skin and fat that remains after previously obese individuals have lost a significant amount of weight, in a variety of places including the torso, upper arms, chest, and thighs."
+    },
+    {
+      "feature": "occupant",
+      "value": "bodypiercing",
+      "definition": "Businesses specializing in piercing of the body."
+    },
+    {
+      "feature": "occupant",
+      "value": "books",
+      "definition": "A business specializing in the sale of books"
+    },
+    {
+      "feature": "occupant",
+      "value": "booksmagazinesmusicvideo",
+      "definition": "A business specializing in the sale of books, magazines, music, video and related media"
+    },
+    {
+      "feature": "occupant",
+      "value": "botanicalgarden",
+      "definition": "Grounds which display ornamental plants and flora."
+    },
+    {
+      "feature": "occupant",
+      "value": "bowlingalley",
+      "definition": "Bowling alleys. Do not use for vendors or retailers of bowling products."
+    },
+    {
+      "feature": "occupant",
+      "value": "boxing",
+      "definition": "Facilities providing boxing classes, the activity of boxing or sport of fighting with the fists."
+    },
+    {
+      "feature": "occupant",
+      "value": "brazilian",
+      "definition": "An establishment specializing in Brazilian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "brazilian.centralbrazil",
+      "definition": "A restaurant specializing in Central Brazilian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "brazilian.empanadas",
+      "definition": "A restaurant specializing in Brazilian-style stuffed bread or pastry baked or fried."
+    },
+    {
+      "feature": "occupant",
+      "value": "brazilian.northeasternbrazil",
+      "definition": "A restaurant specializing in Northeastern Brazilian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "brazilian.northernbrazil",
+      "definition": "A restaurant specializing in Northern Brazilian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "breakfastandbrunch",
+      "definition": "An establishment open for breakfast/brunch and offering food"
+    },
+    {
+      "feature": "occupant",
+      "value": "brewery",
+      "definition": "Businesses that produce and sell beers and ales; some breweries also serve food in a restaurant setting."
+    },
+    {
+      "feature": "occupant",
+      "value": "brewpub",
+      "definition": "An establishment selling beer brewed on the premises and often including a restaurant."
+    },
+    {
+      "feature": "occupant",
+      "value": "bridalstore",
+      "definition": "A business specializing in the wedding dresses and associated accessories for the bridal party for a wedding."
+    },
+    {
+      "feature": "occupant",
+      "value": "british",
+      "definition": "An establishment specializing in traditional English cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "bubbletea",
+      "definition": "Shops specializing in the sale of boba milk tea, also known as pearl milk tea, a Taiwanese tea-based drink containing a tea base mixed with fruit or milk. Ice-blended versions are typically mixed with fruit or syrup, creating a slushy consistency. Most contain small chewy tapioca balls."
+    },
+    {
+      "feature": "occupant",
+      "value": "buffet",
+      "definition": "An establishment specializing in serving food where customers have to dish up their own meals. Often it is pay for a seat rather than à la carte style of service."
+    },
+    {
+      "feature": "occupant",
+      "value": "buildingsupplies",
+      "definition": "Businesses that sell construction materials such as bricks, lumber and/or tiles."
+    },
+    {
+      "feature": "occupant",
+      "value": "bulgarian",
+      "definition": "A restaurant specializing in Bulgarian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "bulkmedicalbilling",
+      "definition": "A business offering payment options under the Medicare system of universal health insurance in Australia."
+    },
+    {
+      "feature": "occupant",
+      "value": "bungeejumping",
+      "definition": "A business that offers an activity that involves jumping from a tall structure while connected to a large elastic cord."
+    },
+    {
+      "feature": "occupant",
+      "value": "burgers",
+      "definition": "An establishment specializing in serving burgers"
+    },
+    {
+      "feature": "occupant",
+      "value": "burmese",
+      "definition": "An establishment specializing in Burmese cuisine. (Burma is now known as Myanmar)"
+    },
+    {
+      "feature": "occupant",
+      "value": "businesscampus",
+      "definition": "A collection of multiple commercial buildings where business is operated from them"
+    },
+    {
+      "feature": "occupant",
+      "value": "businessconsulting",
+      "definition": "A person or business who offer their expertise in improving other businesses operations"
+    },
+    {
+      "feature": "occupant",
+      "value": "busrental",
+      "definition": "A business specializing in offering the lease of large motor vehicle, having a long body, equipped with seats or benches for passengers, usually operating as part of a scheduled service."
+    },
+    {
+      "feature": "occupant",
+      "value": "busstop",
+      "definition": "A designated place where buses stop for passengers to board or alight from a bus."
+    },
+    {
+      "feature": "occupant",
+      "value": "butcher",
+      "definition": "Businesses specializing in the butchering and preparation of meats."
+    },
+    {
+      "feature": "occupant",
+      "value": "cabinets",
+      "definition": "Businesses or individuals specializing in cabinet making, installation and/or servicing."
+    },
+    {
+      "feature": "occupant",
+      "value": "cafe",
+      "definition": "An establishment serving food, typically in a more relaxed environment than a traditional restaurant. Usually open for lunch rather than dinner. Please note that Cafe is a very general moniker and as such something with Cafe in the name does not not mean it has to be in this category."
+    },
+    {
+      "feature": "occupant",
+      "value": "cafeteria",
+      "definition": "An establishment serving food, typically in a space where customers order and collect their food and take it to a cashier to pay for it prior to eating it. The space also has seating just beyond this area. Do not confuse with a Cafe or Coffee & Tea categories."
+    },
+    {
+      "feature": "occupant",
+      "value": "cajun",
+      "definition": "An establishment specializing in cuisine that originated from the region around the Bayou area of the Gulf of Mexico and in particular New Orleans."
+    },
+    {
+      "feature": "occupant",
+      "value": "cakes",
+      "definition": "A business that sells sweet, baked, breadlike food."
+    },
+    {
+      "feature": "occupant",
+      "value": "calligraphy",
+      "definition": "A business or individual who specializes in the art of writing and/or teaching calligraphy."
+    },
+    {
+      "feature": "occupant",
+      "value": "cambodian",
+      "definition": "An establishment specializing in Cambodian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "canadian.modern",
+      "definition": "A restaurant specializing in contemporary Canadian cuisine which may include fusions with other culinary traditions."
+    },
+    {
+      "feature": "occupant",
+      "value": "candy",
+      "definition": "Stores specializing in the sale of confections, chocolates, and candy."
+    },
+    {
+      "feature": "occupant",
+      "value": "candy.dagashi",
+      "definition": "A store that primarily sells dagashi, cheap candies and snack foods that can generally be bought for between 5 and 10 yen. Most dagashi are packaged in bright, childish wrapping and sometimes come with a small toy or prize. Note: a store that sells dagashi is called a dagashiya)."
+    },
+    {
+      "feature": "occupant",
+      "value": "cannabisdispensary",
+      "definition": "A store permitted to sell legal medical or recreational cannabis. Generally speaking, customers need a referral from a medical professional in order to purchase from a cannabis dispensary."
+    },
+    {
+      "feature": "occupant",
+      "value": "canteen",
+      "definition": "A type of food service location in which there is little or no waiting staff table service, whether a restaurant or within an institution such as a large office building or school."
+    },
+    {
+      "feature": "occupant",
+      "value": "cardioclasses",
+      "definition": "Classes emphasizing cardio exercise (aerobics), such as stairclimbing, jumping jacks, or elliptical training."
+    },
+    {
+      "feature": "occupant",
+      "value": "cardiology",
+      "definition": "Doctors specializing in the functions of the heart."
+    },
+    {
+      "feature": "occupant",
+      "value": "cards.stationery"
+    },
+    {
+      "feature": "occupant",
+      "value": "careercounseling",
+      "definition": "A person or business who offers help and guidance in choosing a career or selecting career opportunities"
+    },
+    {
+      "feature": "occupant",
+      "value": "caribbean",
+      "definition": "An establishment specializing in Caribbean cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "caricaturist",
+      "definition": "Individuals specializing in the creation of stylized drawings of people, often at fairs or other large events."
+    },
+    {
+      "feature": "occupant",
+      "value": "carouselride",
+      "definition": "A carousel, roundabout, or merry-go-round, is an amusement ride consisting of a rotating circular platform with seats for riders."
+    },
+    {
+      "feature": "occupant",
+      "value": "carpet",
+      "definition": "A retail establishment or showroom for the viewing and sale of carpets."
+    },
+    {
+      "feature": "occupant",
+      "value": "carrental",
+      "definition": "A business that rents and leases motor vehicles. Businesses that rent trucks for moving and related purposes should be categorized under truck rentalservices."
+    },
+    {
+      "feature": "occupant",
+      "value": "catering",
+      "definition": "Businesses specializing in the preparation, delivery, and serving of food for events. Should be used primarily for businesses that cater exclusively. If the business is a restaurant, food truck, or deli, use the Catering attribute."
+    },
+    {
+      "feature": "occupant",
+      "value": "cellphoneaccessories",
+      "definition": "A business that sells mobile phone accessories such as cases, cables, screens, etc. Not to be confused with stores that sell phones."
+    },
+    {
+      "feature": "occupant",
+      "value": "challengecourse",
+      "definition": "Facilities offering physically demanding obstacle courses, usually outdoors, for the purpose of team building. Includes zipline tours and rope courses."
+    },
+    {
+      "feature": "occupant",
+      "value": "champagnebar",
+      "definition": "A venue where their primary business is serving champagne to the public."
+    },
+    {
+      "feature": "occupant",
+      "value": "cheese",
+      "definition": "Businesses that specialize in the sale of specialty cheese or dairy products."
+    },
+    {
+      "feature": "occupant",
+      "value": "cheesesteaks",
+      "definition": "An establishment specializing in Cheesesteaks."
+    },
+    {
+      "feature": "occupant",
+      "value": "chickenshop",
+      "definition": "An establishment specializing in cooking chicken, typically takeaway service."
+    },
+    {
+      "feature": "occupant",
+      "value": "chickenwings",
+      "definition": "An establishment specializing in serving chicken wings."
+    },
+    {
+      "feature": "occupant",
+      "value": "childbirthschool",
+      "definition": "Individuals or businesses specializing in the education of new mothers and their partners, or other individuals invited to the child-birthing process, usually in a class setting."
+    },
+    {
+      "feature": "occupant",
+      "value": "childcare",
+      "definition": "A facility or service that watches over and cares for children, usually for regularly scheduled intervals and at a location other than a family's home."
+    },
+    {
+      "feature": "occupant",
+      "value": "chilean",
+      "definition": "A restaurant specializing in Chilean cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "chimneycakes",
+      "definition": "A business that specializes in chimney cakes, which are hollow, cylindrical-shaped, bread-like pastries baked on a spit over an open flame. The crust is crispy and the surface of the cake is golden-brown color and is often topped with ingredients such as ground walnut or powdered cinnamon. (Note: known as Kürtőskalács in Hungarian or Trdelní in Czech.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese",
+      "definition": "An establishment specializing in Chinese cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.cantonese",
+      "definition": "An establishment specializing in Cantonese cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.dimsum",
+      "definition": "What tapas is to Spanish food, dim sum is to Chinese food."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.fuzhou",
+      "definition": "A restaurant specializing in Fuzhou cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.hainan",
+      "definition": "A restaurant specializing in Hainan cuisine, which is derived from the cooking styles of the peoples of Hainan province in China. The food is usually lighter, less oily, and more mildly seasoned than that of the Chinese mainland. Seafood predominates the menu, as shrimp, crab, and freshwater and ocean fish are widely available. Well known dishes include Hainan chicken rice, Hainan breakfast noodles, wenchang chicken, jiaji duck, and hele crab."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.hakka",
+      "definition": "A restaurant specializing in Hakka cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.henghwa",
+      "definition": "A restaurant specializing in Heng Hwa cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.hokkien",
+      "definition": "A restaurant specializing in a dish in Malaysian and Singaporean cuisine that has its origins in the cuisine of China's Fujian (Hokkien) province. In its most common form, the dish consists of egg noodles and rice noodles stir-fried."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.hunan",
+      "definition": "An establishment serving Hunan cuisine, also known as Xiang cuisine, consists of the cuisines of the Xiang River region, Dongting Lake, and western Hunan province in China"
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.pekinese",
+      "definition": "An establishment specializing in Pekinese cuisine, a regional Chinese cuisine from Beijing"
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.shanghainese",
+      "definition": "An establishment specializing in cuisine from Shanghai."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.szechuan",
+      "definition": "An establishment specializing in Szechuan cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinese.teochew",
+      "definition": "Teochew cuisine is a regional Chinese cuisine, also known as Chiuchow cuisine, Chaozhou cuisine or Chaoshan cuisine, originated from the Chaoshan region in the east of Guangdong province, China."
+    },
+    {
+      "feature": "occupant",
+      "value": "chinesebazaar",
+      "definition": "A marketplace of many vendors offering goods and services associated with China and Chinese culture."
+    },
+    {
+      "feature": "occupant",
+      "value": "chiropractic",
+      "definition": "A business or professional offering services related to the care and treatment of disorders and injuries of the skeleton and muscles"
+    },
+    {
+      "feature": "occupant",
+      "value": "chocolate",
+      "definition": "Businesses that specialize in the production of chocolate."
+    },
+    {
+      "feature": "occupant",
+      "value": "christmastrees",
+      "definition": "A store that primarily sells Christmas trees"
+    },
+    {
+      "feature": "occupant",
+      "value": "churros",
+      "definition": "A business that sells fried-dough pastry-based snacks."
+    },
+    {
+      "feature": "occupant",
+      "value": "cider"
+    },
+    {
+      "feature": "occupant",
+      "value": "cigarbar",
+      "definition": "A cigar bar (or lounge) is an establishment that caters to patrons who smoke cigars."
+    },
+    {
+      "feature": "occupant",
+      "value": "cinema"
+    },
+    {
+      "feature": "occupant",
+      "value": "cityhall",
+      "definition": "Administration building of a municiple government."
+    },
+    {
+      "feature": "occupant",
+      "value": "climbing",
+      "definition": "Outdoor climbing locations, or facilities designed for indoor rock climbing."
+    },
+    {
+      "feature": "occupant",
+      "value": "clinic",
+      "definition": "An outpatient healthcare facility, usually providing primary care. A medical practice can be considered a clinic. Not to be confused with hospital departments."
+    },
+    {
+      "feature": "occupant",
+      "value": "clockrepair"
+    },
+    {
+      "feature": "occupant",
+      "value": "clothing",
+      "definition": "General clothing category"
+    },
+    {
+      "feature": "occupant",
+      "value": "clothing.bespoke",
+      "definition": "A business specializing in tailor made clothing and footwear."
+    },
+    {
+      "feature": "occupant",
+      "value": "clothing.childrens",
+      "definition": "A business specializing in the sale of clothing for young children"
+    },
+    {
+      "feature": "occupant",
+      "value": "clothing.mens",
+      "definition": "A business specializing in mens fashion"
+    },
+    {
+      "feature": "occupant",
+      "value": "clothing.plussize",
+      "definition": "A business specializing in apparel designed for larger people"
+    },
+    {
+      "feature": "occupant",
+      "value": "clothing.womens",
+      "definition": "A business specializing in womens fashion"
+    },
+    {
+      "feature": "occupant",
+      "value": "cocktailbar",
+      "definition": "A venue where their primary business is serving cocktails to the public."
+    },
+    {
+      "feature": "occupant",
+      "value": "coffee",
+      "definition": "Businesses that specialize in the sale of tea and coffee. Do not use for food establishments with only a handful of tea or coffee drinks."
+    },
+    {
+      "feature": "occupant",
+      "value": "coffee.tea"
+    },
+    {
+      "feature": "occupant",
+      "value": "coffeeroaster",
+      "definition": "A business that roasts and sells its own coffee beans and usually serves coffee drinks onsite as well. Often times coffee roasteries will have roasting equipment on site.Ê"
+    },
+    {
+      "feature": "occupant",
+      "value": "coffeeteasupplies",
+      "definition": "A business specializing in equipment and accessories for brewing coffee and/or tea."
+    },
+    {
+      "feature": "occupant",
+      "value": "coincashingkiosk",
+      "definition": "A kiosk or machine where one can convert coins into cash"
+    },
+    {
+      "feature": "occupant",
+      "value": "college",
+      "definition": "Post-secondary educational institutions offering courses of specialized study in a variety of subjects."
+    },
+    {
+      "feature": "occupant",
+      "value": "colombian",
+      "definition": "An establishment specializing in Colombian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "comedyclub",
+      "definition": "A venue with a performance space that primarily hosts comedians"
+    },
+    {
+      "feature": "occupant",
+      "value": "comfortfood",
+      "definition": "An establishment serving typically simple nostalgic food. Usually this is American style, but will differ culture to culture."
+    },
+    {
+      "feature": "occupant",
+      "value": "comicbooks",
+      "definition": "A business specializing in the sale of comic books, graphic novels and associated paraphernalia"
+    },
+    {
+      "feature": "occupant",
+      "value": "commercialrealestate",
+      "definition": "A complex or building used for commercial use which includes offices and retail shops."
+    },
+    {
+      "feature": "occupant",
+      "value": "commissionedartists",
+      "definition": "An individual who creates artwork for others, either on commission or as a product.Ê"
+    },
+    {
+      "feature": "occupant",
+      "value": "communitybookbox",
+      "definition": "A free community book exchange where anybody can take a book and leave a book from a box typically located outside residences or by the curb. These boxes full of books are commonly known as \"Little Free Library\"."
+    },
+    {
+      "feature": "occupant",
+      "value": "communitycenter",
+      "definition": "A space maintained by the local community, that is host to social, educational and recreational activities."
+    },
+    {
+      "feature": "occupant",
+      "value": "computersandaccessories",
+      "definition": "A business that sells computer hardware. This includes complete computers, laptops and tablets, as well as computer parts and accessories."
+    },
+    {
+      "feature": "occupant",
+      "value": "conceptshop",
+      "definition": "A store, generally in the fashion industry, that does not specialize in a specific type of product but rather offers a range of products that appeal to a particular type of life style, social scene or segment of consumers."
+    },
+    {
+      "feature": "occupant",
+      "value": "concourse",
+      "definition": "A large open area inside or in front of a public building, as in an airport or train station."
+    },
+    {
+      "feature": "occupant",
+      "value": "condominium",
+      "definition": "A building or complex of buildings where specified units of the property are separately owned, and the remainder of the property is collectively owned; people buy the individual housing units and have access to common facilities such as hallways, heating system, elevators, exterior areas, and other amenities, which are governed and managed by a homeowners association. Commonly known as condos. Not to be confused with Apartments, which are individually rented (not owned) and are managed by either the landlord or a property management company."
+    },
+    {
+      "feature": "occupant",
+      "value": "congee",
+      "definition": "A restaurant specializing in a type of rice porridge or gruel popular in many Asian countries."
+    },
+    {
+      "feature": "occupant",
+      "value": "constructionequipmentrental",
+      "definition": "A business that rent tools, equipment and machines for construction and utility purposes."
+    },
+    {
+      "feature": "occupant",
+      "value": "contractors",
+      "definition": "A business or individual that coordinates and manages the materials, labor, equipment and services of major construction projects including home construction and remodeling."
+    },
+    {
+      "feature": "occupant",
+      "value": "conveniencestore",
+      "definition": "Small stores selling snacks, small food items, and sundries."
+    },
+    {
+      "feature": "occupant",
+      "value": "conveyorsushi",
+      "definition": "A type of sushi restaurant where the plates with the sushi are placed on a rotating conveyor belt or moat that winds through the restaurant and moves past every table and counter seat."
+    },
+    {
+      "feature": "occupant",
+      "value": "cooking.instruction",
+      "definition": "A service offering classes on how to cook."
+    },
+    {
+      "feature": "occupant",
+      "value": "cookingschool",
+      "definition": "Schools specializing in teaching cooking and culinary technique. Do not use for independent cooking classes."
+    },
+    {
+      "feature": "occupant",
+      "value": "copyshop",
+      "definition": "A store offering personal and commercial printing and photocopying services"
+    },
+    {
+      "feature": "occupant",
+      "value": "corporateheadquarters",
+      "definition": "The main offices of a corporation where most, if not all, of the important functions of an organization are coordinated."
+    },
+    {
+      "feature": "occupant",
+      "value": "corporateoffices",
+      "definition": "A building that belongs to or is leased by a corporation to provide office space and office amenities. Unlike other types of offices (eg. doctor's office), corporate facilities often have restricted access and non-employees are typically allowed in by appointment only."
+    },
+    {
+      "feature": "occupant",
+      "value": "corsican",
+      "definition": "An establishment specializing in Corsican cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "cosmetics",
+      "definition": "Businesses specializing in the sale of products such as cosmetics, shampoo, and hair styling."
+    },
+    {
+      "feature": "occupant",
+      "value": "cosmeticsurgery",
+      "definition": "Doctors specializing in enhancing or repairing the physical appearance, typically with procedures such as facelifts, breast augmentations, and nose reshaping."
+    },
+    {
+      "feature": "occupant",
+      "value": "cosmetologyschool",
+      "definition": "Businesses specializing in teaching the art of body and hair beautification. If the school offers another service, it should be given a separate listing."
+    },
+    {
+      "feature": "occupant",
+      "value": "costumes",
+      "definition": "A store that sells or rents out costumes"
+    },
+    {
+      "feature": "occupant",
+      "value": "countertopinstallation",
+      "definition": "A business or individual providing countertop installation and expertise."
+    },
+    {
+      "feature": "occupant",
+      "value": "countryclub",
+      "definition": "Clubs providing sports facilities and amenities, often requiring paid membership. Examples include golf, tennis, and squash, as well as social clubs (cafes, halls, ballrooms, and groups)."
+    },
+    {
+      "feature": "occupant",
+      "value": "courier",
+      "definition": "A business or individual that delivers goods or messages. Couriers are distinguished from general mail and shipping services by such features as speed, security, tracking, specialization and individualization of express services."
+    },
+    {
+      "feature": "occupant",
+      "value": "crepes",
+      "definition": "An establishment specializing in crepes, be it the sweet and/or savory varieties."
+    },
+    {
+      "feature": "occupant",
+      "value": "cryotherapy",
+      "definition": "A medical technique that uses extreme low temperatures to destroy cells and is often used to treat a variety of benign and malignant tissue damage (lesions). The surgical version of this treatment is known as cryosurgery. This category can also be used for medical spas or athletic training facilities that offer whole body cryotherapy (or systemic cryotherapy), which is an alternative treatment that involves exposing individuals to extremely cold dry air for two to four minutes to fight aging, inflammation, uneven skin tone, and physical maladies. Many athletes use cryotherapy treatment to alleviate delayed onset muscle soreness after exercise."
+    },
+    {
+      "feature": "occupant",
+      "value": "cuban",
+      "definition": "An establishment specializing in Cuban cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "culturalcenter",
+      "definition": "Facilities or organizations dedicated to the promotion of culture and the arts."
+    },
+    {
+      "feature": "occupant",
+      "value": "cupcakes",
+      "definition": "Businesses that specialize in the sale of cupcakes."
+    },
+    {
+      "feature": "occupant",
+      "value": "currencyexchange",
+      "definition": "Businesses that exchange currency, usually for international travelers."
+    },
+    {
+      "feature": "occupant",
+      "value": "customcakes",
+      "definition": "A business or individual specializing in making cakes per the customer's request. Common examples include cakes with pictures on it, cakes that resemble an object (e.g. a purse, a basketball, tennis shoes, an animal, etc.), or themed cakes (e.g. princess theme, Hello Kitty, vampire, Star Wars, etc.) These custom cakes are typically one-of-a-kind and require advance notice; customized cakes cannot be found readily available at a cake shop. This category should not be used as an attribute for bakeries that offer a custom cake option; this is for businesses whose core competency is making custom cakes."
+    },
+    {
+      "feature": "occupant",
+      "value": "custommerchandise",
+      "definition": "A company offering to create customized items and apparel for other companies or events."
+    },
+    {
+      "feature": "occupant",
+      "value": "cyclingclass",
+      "definition": "Group classes where participants are instructed to ride stationary bikes."
+    },
+    {
+      "feature": "occupant",
+      "value": "cypriot",
+      "definition": "An establishment specializing in Cypriot cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "czech",
+      "definition": "An establishment specializing in cuisine from the Czech Republic."
+    },
+    {
+      "feature": "occupant",
+      "value": "danceclub",
+      "definition": "Also known as a nightclub, this is an entertainment focused venue that focuses on music and dancing. Typically operating late into the night."
+    },
+    {
+      "feature": "occupant",
+      "value": "danceschool",
+      "definition": "Schools or individual instructors that specialize in dancing and the techniques of movement."
+    },
+    {
+      "feature": "occupant",
+      "value": "dancestudio",
+      "definition": "Facilities teaching dance and providing dance classes; considered less formal than a dance school."
+    },
+    {
+      "feature": "occupant",
+      "value": "dancewear",
+      "definition": "A store that primarily sells clothing and accessories intended for dancing."
+    },
+    {
+      "feature": "occupant",
+      "value": "danish",
+      "definition": "An establishment specializing in Danish cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "datarecovery",
+      "definition": "A business or individual that specializes in the recovery of digital data when it cannot be accessed under normal circumstances including from damaged or malfunctioning storage devices."
+    },
+    {
+      "feature": "occupant",
+      "value": "dayspa",
+      "definition": "Businesses offering traditional and alternative spa treatments such as Boxtox injections, chemical peels, laser hair removals, and cellulite and vain treatments."
+    },
+    {
+      "feature": "occupant",
+      "value": "dealer.usedvehicle",
+      "definition": "A business that primarily sells used/pre-owned vehicles."
+    },
+    {
+      "feature": "occupant",
+      "value": "delicatessen",
+      "definition": "An establishment specializing in cured meats, sometimes also selling made to order sandwiches and salads."
+    },
+    {
+      "feature": "occupant",
+      "value": "delicatessen.sandwiches",
+      "definition": "A business where prepared foods are sold."
+    },
+    {
+      "feature": "occupant",
+      "value": "dentalhygiene",
+      "definition": "Health professionals that clean teeth, examine patients for signs of oral diseases such as gingivitis, and provide other preventive dental care."
+    },
+    {
+      "feature": "occupant",
+      "value": "dentistry",
+      "definition": "Not to be used as category. Practices and professionals of general dentistry should be listed under general dentistry."
+    },
+    {
+      "feature": "occupant",
+      "value": "dentistry.cosmetic",
+      "definition": "A clinic offering dental work that improves the appearance of a person's teeth, gums and/or bite. Can include services such as bleaching and porcelain veneers."
+    },
+    {
+      "feature": "occupant",
+      "value": "dentistry.general",
+      "definition": "A clinic or dentist offering regular checkup and all-ages service, such as cleanings, crowns and bridges, and gum disease treatment."
+    },
+    {
+      "feature": "occupant",
+      "value": "dentistry.pediatric",
+      "definition": "A dentist or clinic that specializes in the dental care and oral health of children"
+    },
+    {
+      "feature": "occupant",
+      "value": "departmentstore"
+    },
+    {
+      "feature": "occupant",
+      "value": "dermatology",
+      "definition": "Doctors that specialize in skin problems."
+    },
+    {
+      "feature": "occupant",
+      "value": "desserts",
+      "definition": "Businesses that specialize in the sale of specialty desserts such as pastries, cakes and ice cream."
+    },
+    {
+      "feature": "occupant",
+      "value": "diagnosticimaging",
+      "definition": "Businesses providing technologies that doctors use to look inside patients' bodies for clues about a medical condition, e.g. MRI, Dedicated Extremity MRI, CT (Catscan), Ultrasound, Digital Mammography, Breast MRI, MRI Guided Biopsy, Stereotactic Breast Biopsy, DEXA Scan (Bone Densitometry), X-ray, Fluoroscopy, and Creatinine Lab Services."
+    },
+    {
+      "feature": "occupant",
+      "value": "diagnosticservices",
+      "definition": "Businesses that provide both lab testing and diagnostic imaging. If services are limited more to one than the other, categorize more specifically using the definitions below."
+    },
+    {
+      "feature": "occupant",
+      "value": "dialysis",
+      "definition": "Clinics that specialize in dialysis, a procedure that cleans the blood of people with kidney disease or kidney failure."
+    },
+    {
+      "feature": "occupant",
+      "value": "dietician",
+      "definition": "A qualified health professional who helps promote good health through proper nutritional habits. A dietician is an expert in prescribing therapeutic nutrition. Unlike a nutritionist, dietitians must meet certain educational and training qualifications."
+    },
+    {
+      "feature": "occupant",
+      "value": "digitizingservices",
+      "definition": "A business specializing in converting information and/or analog media into digital formats (e.g. scanning paper documents, transferring film negatives, slides, and traditional paper photos to digital files, transferring a VHS video to a DVD, converting your audio cassettes into digital formats, etc.). Digitizing information makes it easier to preserve, access, and share text, audio, video, and/or graphics over the Internet or on digital electronic devices."
+    },
+    {
+      "feature": "occupant",
+      "value": "diner",
+      "definition": "An establishment somewhere between a cafe and a restaurant. Generally has a counter, and wait staff, food is American and offers late operating hours."
+    },
+    {
+      "feature": "occupant",
+      "value": "dinnertheater",
+      "definition": "A form of entertainment that combines a restaurant meal with a live performance (musical/play/dance/etc). Sometimes the play is incidental entertainment, secondary to the meal, in the style of a sophisticated night club, or the play may be a major production with dinner less important. A dinner theater typically requires the management of three distinct entities: a live theater, a restaurant, and usually, a bar."
+    },
+    {
+      "feature": "occupant",
+      "value": "discountstore",
+      "definition": "A business specializing in the sale of items at a much cheaper rate than elsewhere"
+    },
+    {
+      "feature": "occupant",
+      "value": "distillery",
+      "definition": "Businesses that produce and sell distilled spirits, e.g. vodka, gin, and rum."
+    },
+    {
+      "feature": "occupant",
+      "value": "divebar",
+      "definition": "A bar that offers a basic but comfortable drinking experience. usually, a local neighborhood bar."
+    },
+    {
+      "feature": "occupant",
+      "value": "diyfood",
+      "definition": "Businesses providing \"take and bake\" meals, meals that are pre-prepared or frozen, that the consumer typically cooks or reheats. Do not use for Food Delivery Services."
+    },
+    {
+      "feature": "occupant",
+      "value": "dmv",
+      "definition": "A government department that deals with vehicular licensing and registration"
+    },
+    {
+      "feature": "occupant",
+      "value": "dominican",
+      "definition": "An establishment specializing in cuisine from the Dominican Republic."
+    },
+    {
+      "feature": "occupant",
+      "value": "donair",
+      "definition": "A restaurant specializing in a dish made of meat cooked on a vertical rotisserie."
+    },
+    {
+      "feature": "occupant",
+      "value": "donationcenter",
+      "definition": "A facility where people can drop off donations."
+    },
+    {
+      "feature": "occupant",
+      "value": "donuts",
+      "definition": "Shops that specialize in the sale of donuts."
+    },
+    {
+      "feature": "occupant",
+      "value": "doorsalesandinstallation",
+      "definition": "Businesses or individuals with a specialization in door sales and installation"
+    },
+    {
+      "feature": "occupant",
+      "value": "drivingrange",
+      "definition": "An area where golfers can practice their golf swing. It can be either indoor or outdoor. Synonyms: golf range, practice range or learning center."
+    },
+    {
+      "feature": "occupant",
+      "value": "drivingschool",
+      "definition": "Businesses specializing in driving instruction."
+    },
+    {
+      "feature": "occupant",
+      "value": "drycleaning",
+      "definition": "A business specializing in the cleaning process for clothing and textiles using a chemical solvent other than water."
+    },
+    {
+      "feature": "occupant",
+      "value": "drycleaninglaundry"
+    },
+    {
+      "feature": "occupant",
+      "value": "dumplings",
+      "definition": "An establishment specializing in dumplings, a dish that consists of small pieces of dough (made from a variety of starch sources), often wrapped around a filling (as in ravioli or wontons). The dough can be based on bread, flour, or potatoes, and may be filled with fish, meat, sweets, or vegetables. They may be cooked by boiling, frying, simmering, or steaming. Dumplings may be savoury or sweet and can be eaten by themselves, with gravy or sauce, or in soups or stews."
+    },
+    {
+      "feature": "occupant",
+      "value": "dumpsterrental",
+      "definition": "A business that rents out a variety of recycling and trash dumpster containers. Typically, these businesses will drop off the dumpster at the client's location and then return at a later time to haul it away/empty it. Unlike Junk Removal & Hauling, dumpster rentalservices companies do not help the client do any actual cleaning and they leave the dumpster with the client for use. Most people rent dumpsters for construction projects and cleanouts."
+    },
+    {
+      "feature": "occupant",
+      "value": "dutyfree",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment where a pedestrian may purchase duty free goods and services."
+    },
+    {
+      "feature": "occupant",
+      "value": "earnosethroat",
+      "definition": "Doctors that specialize in ear, nasal, and respiratory problems. Often called ENTs."
+    },
+    {
+      "feature": "occupant",
+      "value": "easterneuropean",
+      "definition": "An establishment specializing in cuisine from eastern Europe"
+    },
+    {
+      "feature": "occupant",
+      "value": "eatertainment",
+      "definition": "An establishment specializing in experiences which combine eating with entertainment; specifically the sector of the restaurant industry comprising restaurant chains based on an entertainment theme, such as sport, music, or film."
+    },
+    {
+      "feature": "occupant",
+      "value": "editorialservices",
+      "definition": "A person or business who offers assistance in terms of editing documents"
+    },
+    {
+      "feature": "occupant",
+      "value": "education"
+    },
+    {
+      "feature": "occupant",
+      "value": "educationservices",
+      "definition": "Businesses providing educational planning and counseling services. Can be used for businesses providing college placement advice."
+    },
+    {
+      "feature": "occupant",
+      "value": "egyptian",
+      "definition": "An establishment specializing in Egyptian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "electricians",
+      "definition": "A business or professional providing electrical services such as wiring and testing. Electricians may specialize in the servicing of equipment and machines in addition to work on residential or commercial buildings."
+    },
+    {
+      "feature": "occupant",
+      "value": "electronicappliances",
+      "definition": "A business specializing in the sale of electronics and electrical appliances like TVs and radios."
+    },
+    {
+      "feature": "occupant",
+      "value": "electronicparts",
+      "definition": "A business specializing in the sale of electronic components such as semiconductors, vacuum tubes, resistors and capacitors."
+    },
+    {
+      "feature": "occupant",
+      "value": "electronicsrepair",
+      "definition": "A business or individual specializing in the repair and troubleshooting of electronics and electrical devices."
+    },
+    {
+      "feature": "occupant",
+      "value": "elementaryschool",
+      "definition": "Primary schools generally for children ages 4-12."
+    },
+    {
+      "feature": "occupant",
+      "value": "embroiderycrochet",
+      "definition": "A business specializing in the sale of supplies for embroidery and crocheting."
+    },
+    {
+      "feature": "occupant",
+      "value": "emergencymedicine",
+      "definition": "A doctor/professional specializing in the care of critically ill patients."
+    },
+    {
+      "feature": "occupant",
+      "value": "emissionstesting",
+      "definition": "Businesses that test automobile emission standards."
+    },
+    {
+      "feature": "occupant",
+      "value": "empanadas",
+      "definition": "Food establishments specializing in empanadas, a pastry filled with a variety of stuffings."
+    },
+    {
+      "feature": "occupant",
+      "value": "employmentagency",
+      "definition": "A person or business that connect job seekers with job openings"
+    },
+    {
+      "feature": "occupant",
+      "value": "endodontics",
+      "definition": "A clinic or dentist specializing in the treatment of dental pulp. Endodontists perform a variety of procedures including \"root canal therapy\" and the treatment of cracked teeth or dental trauma."
+    },
+    {
+      "feature": "occupant",
+      "value": "engraving",
+      "definition": "A business or individual that offers engraving services by incising or cutting grooves into the surface of certain materials to form designs or text."
+    },
+    {
+      "feature": "occupant",
+      "value": "escapegame",
+      "definition": "Games providing an entertaining challenge to escape from a room or other enclosed area using clues and logic."
+    },
+    {
+      "feature": "occupant",
+      "value": "ethiopian",
+      "definition": "An establishment specializing in Ethiopian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "ethnicgrocerystore",
+      "definition": "Grocery stores specializing in the sale of groceries and household goods imported from one particular country or region."
+    },
+    {
+      "feature": "occupant",
+      "value": "european.modern",
+      "definition": "An establishment specializing in contemporary European cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "eventplanning",
+      "definition": "Businesses or individuals that specialize in planning and coordinating all necessary components of an event, ceremony, or competition."
+    },
+    {
+      "feature": "occupant",
+      "value": "eventspace",
+      "definition": "Locations for event hosting, ceremonies, shows, or parties."
+    },
+    {
+      "feature": "occupant",
+      "value": "experiences",
+      "definition": "The knowledge or mastery of an event or subject gained through involvement in or exposure to it."
+    },
+    {
+      "feature": "occupant",
+      "value": "eyelashes",
+      "definition": "Businesses specializing in the enhancement of eyelashes and false extensions."
+    },
+    {
+      "feature": "occupant",
+      "value": "eyewear.opticians"
+    },
+    {
+      "feature": "occupant",
+      "value": "fabricstore",
+      "definition": "A business specializing in the sale of supplies of fabric"
+    },
+    {
+      "feature": "occupant",
+      "value": "fairground",
+      "definition": "An outside area dedicated to hosting the fair, carnival, etc.  May include pig racing, horse racing. Rides, food, beverages, arcade games, etc, can be found."
+    },
+    {
+      "feature": "occupant",
+      "value": "falafel",
+      "definition": "An establishment specializing in falafel dishes"
+    },
+    {
+      "feature": "occupant",
+      "value": "familyfriendly"
+    },
+    {
+      "feature": "occupant",
+      "value": "familyfuncenter",
+      "definition": "Includes such entities as: Arcades, Miniature golf courses, Go-kart race courses, alpine sides, rope courses, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "familymedicine",
+      "definition": "Primary healthcare division that provides continuing and comprehensive care for people of all ages, usually in the context of the patient's family and community. Frequently interchangeable with General Practice."
+    },
+    {
+      "feature": "occupant",
+      "value": "familyplanning",
+      "definition": "An establishment that offers health information and clinical services for couples in a committed relationships based on factors involved in deciding if and when to have children."
+    },
+    {
+      "feature": "occupant",
+      "value": "familyrestaurant",
+      "definition": "Also known as famiresu, family restaurants are a type of restaurant found in Japan, usually belonging to a chain and serving a wide variety of food types including Japanese, Chinese and Wester. They are usually fairly large with spaciously arranged tables, often open 24-hours per day and less expensive than more formal restaurants."
+    },
+    {
+      "feature": "occupant",
+      "value": "farm",
+      "definition": "Businesses located on a plot of land dedicated to food production."
+    },
+    {
+      "feature": "occupant",
+      "value": "farmersmarket",
+      "definition": "Markets that host local food merchants, typically in an open-air public environment."
+    },
+    {
+      "feature": "occupant",
+      "value": "fashion"
+    },
+    {
+      "feature": "occupant",
+      "value": "fashionaccessories",
+      "definition": "A business specializing in the sale of fashion accessories, like bags, gloves, belts, scarves etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "fastfood",
+      "definition": "An establishment specializing in food prepared quickly, of relatively low cost and quality. Main examples would be McDonald's and KFC"
+    },
+    {
+      "feature": "occupant",
+      "value": "fencing",
+      "definition": "Clubs or locations where fencing is played, a sport played using sword-like weapons and protective gear. Do no use for fences and gates. For fences and gates, use homeservices/fencesgates."
+    },
+    {
+      "feature": "occupant",
+      "value": "fengshui",
+      "definition": "A business (often an individual) specializing in feng shui, the Chinese art of determining the most propitious design, orientation, and placement of objects and structures (e.g. graves, buildings, houses, room, parks, etc.) to achieve maximum harmony between the environment's flow of energy (qi or chi) and that of the  occupant/user, which is believed to bring good fortune and health. Feng shui in/at a given place typically changes periodically and feng shui masters may tell its customers to rearrange furniture, place certain objects at specific locations, sleep in certain areas of a room, or to anticipate unwanted events."
+    },
+    {
+      "feature": "occupant",
+      "value": "ferry",
+      "definition": "A boat or ship (a merchant vessel) used to carry (or ferry) primarily passengers, and sometimes vehicles and cargo as well, across a body of water."
+    },
+    {
+      "feature": "occupant",
+      "value": "fieldofplay",
+      "definition": "Intramural sports or recreational fields usually found on college/university campus."
+    },
+    {
+      "feature": "occupant",
+      "value": "filipino",
+      "definition": "An establishment specializing in cuisine from the Philippines"
+    },
+    {
+      "feature": "occupant",
+      "value": "financialservices"
+    },
+    {
+      "feature": "occupant",
+      "value": "fingerprinting",
+      "definition": "A business that offers fingerprinting service, which is taking ink records of a fingerprint, usually for identity-related purposes"
+    },
+    {
+      "feature": "occupant",
+      "value": "firearmstrainingschool",
+      "definition": "Businesses providing classes on the use of firearms."
+    },
+    {
+      "feature": "occupant",
+      "value": "fish",
+      "definition": "A wholesaler or retailer who sells raw fish and seafood."
+    },
+    {
+      "feature": "occupant",
+      "value": "fishandchips",
+      "definition": "An establishment specializing in deep fried fish and hot chips, although not limited to just that. Generally take-away service but may have limited seating as well."
+    },
+    {
+      "feature": "occupant",
+      "value": "fitnessbootcamp",
+      "definition": "Disciplined workout regimes usually held in group classes at fitness facilities or outdoor venues, including parks."
+    },
+    {
+      "feature": "occupant",
+      "value": "fitnessequipment",
+      "definition": "A business specializing in in the sale of fitness eqipment."
+    },
+    {
+      "feature": "occupant",
+      "value": "fitnessinstruction",
+      "definition": "Individuals or organizations specializing in the education or instruction of clients in physical activities."
+    },
+    {
+      "feature": "occupant",
+      "value": "fixedbaseoperator",
+      "definition": "Fixed Base Operator, referred to as FBO, is a commercial business licensed to operate on airport grounds to provide services such as fueling, hangaring, tie-down and parking, aircraft rentalservices, aircraft maintenance, and flight instruction."
+    },
+    {
+      "feature": "occupant",
+      "value": "flatbread"
+    },
+    {
+      "feature": "occupant",
+      "value": "flightinstructionschool",
+      "definition": "Schools providing pilot training and aircraft instruction."
+    },
+    {
+      "feature": "occupant",
+      "value": "floatspa",
+      "definition": "A spa offering floating, an alternative therapy in which an individual floats weightlessly in a dense saline solution for pain/stress relief and meditative/relaxation purposes. Also referred as salt therapy."
+    },
+    {
+      "feature": "occupant",
+      "value": "flooringinstallationandrepair",
+      "definition": "Businesses or individuals with a specialization in flooring installation and repair"
+    },
+    {
+      "feature": "occupant",
+      "value": "floraldesign",
+      "definition": "An establishment which specializes in the art of using plant materials and flowers to create a pleasing and balanced composition."
+    },
+    {
+      "feature": "occupant",
+      "value": "florist"
+    },
+    {
+      "feature": "occupant",
+      "value": "florists",
+      "definition": "A business that primarily sells flowers"
+    },
+    {
+      "feature": "occupant",
+      "value": "flowers",
+      "definition": "A business specializing in in the sale of flowers and other assorted gifts"
+    },
+    {
+      "feature": "occupant",
+      "value": "fondue",
+      "definition": "An establishment specializing in fondue"
+    },
+    {
+      "feature": "occupant",
+      "value": "foodcourt",
+      "definition": "A location serving several types of food from different outlets usually with a common seating area"
+    },
+    {
+      "feature": "occupant",
+      "value": "fooddelivery",
+      "definition": "Businesses specializing in the delivery of food to private residences or businesses. Do not use for restaurants with a physical dine-in location, or CSAs (Community Supported Agriculture)."
+    },
+    {
+      "feature": "occupant",
+      "value": "foodstand",
+      "definition": "Small food operation slightly more permanent than a food cart. Usually selling only a few different items"
+    },
+    {
+      "feature": "occupant",
+      "value": "foodtruck",
+      "definition": "Trucks equipped with kitchen equipment where food is typically served to on-the-go customers wanting a quick bite; can be either stationary or mobile."
+    },
+    {
+      "feature": "occupant",
+      "value": "formalwear",
+      "definition": "A business specializing in formal wear, these may be to sell or rent to customers."
+    },
+    {
+      "feature": "occupant",
+      "value": "formalwear.rental",
+      "definition": "A business specializing in the rentalservices of clothes, typically formal wear."
+    },
+    {
+      "feature": "occupant",
+      "value": "freiduria",
+      "definition": "A restaurant specializing in fried food (fish, seafood, meat, pork, chicken, churros, etc). It is very common in Spain and in Latin America (referred as chicharr—n). Freidur’a or Nikkei are usually displayed along with/part of the biz name."
+    },
+    {
+      "feature": "occupant",
+      "value": "french",
+      "definition": "An establishment specializing in French cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "french.alsatian",
+      "definition": "An establishment specializing in cuisine from Alsatian region of Germany"
+    },
+    {
+      "feature": "occupant",
+      "value": "french.auvergnat",
+      "definition": "An establishment specializing in cuisine from Auvergant region of France"
+    },
+    {
+      "feature": "occupant",
+      "value": "french.baguette",
+      "definition": "A restaurant or business specializing in long thin loafs of French bread that are commonly made from basic lean dough."
+    },
+    {
+      "feature": "occupant",
+      "value": "french.berrichon",
+      "definition": "An establishment specializing in berrichon cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "french.bourguignon",
+      "definition": "A restaurant specializing in French beef stew."
+    },
+    {
+      "feature": "occupant",
+      "value": "french.brasserie",
+      "definition": "A French establishment specializing in simple cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "french.lyonnais",
+      "definition": "A restaurant specializing in the gastronomy of the city of Lyon and surrounding region in France."
+    },
+    {
+      "feature": "occupant",
+      "value": "french.nicois",
+      "definition": "A restaurant specializing in Nicoise cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "french.provencal",
+      "definition": "A restaurant specializing in Provencal cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "friterie",
+      "definition": "A restaurant or kiosk serving quick-service fast food, particularly fries."
+    },
+    {
+      "feature": "occupant",
+      "value": "frozenfoods",
+      "definition": "A business specializing in food that is preserved by freezing."
+    },
+    {
+      "feature": "occupant",
+      "value": "fruitandvegetables",
+      "definition": "A store that sells, fruits, vegetables or both. This category is distinct from grocery stores, which also sell other items."
+    },
+    {
+      "feature": "occupant",
+      "value": "fuelstation",
+      "definition": "A business that sells fuel and engine lubricants for motor vehicles."
+    },
+    {
+      "feature": "occupant",
+      "value": "funeralservices",
+      "definition": "A business that provides funeral or mortuary services and may also include cemeteries and other burial places."
+    },
+    {
+      "feature": "occupant",
+      "value": "furclothing",
+      "definition": "A store that sells fur clothing"
+    },
+    {
+      "feature": "occupant",
+      "value": "furniture",
+      "definition": "A shop that sells furniture, such as tables, chairs, couches, desks. The items sold are of a more general spread of purpose types, not to be confused with specialized stores like mattress stores or outdoor furniture stores."
+    },
+    {
+      "feature": "occupant",
+      "value": "furniture.rental",
+      "definition": "A business that rents or leases home and/or office furniture, usually on a medium- to long-term basis."
+    },
+    {
+      "feature": "occupant",
+      "value": "furniturestore"
+    },
+    {
+      "feature": "occupant",
+      "value": "gardening",
+      "definition": "A business selling all things related to designing, growing and maintaining a garden. This includes plants, grasses, fertilizers, tools and equipment."
+    },
+    {
+      "feature": "occupant",
+      "value": "gastroenterology",
+      "definition": "Doctors specializing the digestive system and its disorders."
+    },
+    {
+      "feature": "occupant",
+      "value": "gastropubs",
+      "definition": "An establishment specializing in beer and good food. Better than usual bar cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "gelato",
+      "definition": "Businesses that specialize in the sale of gelato, an Italian ice cream."
+    },
+    {
+      "feature": "occupant",
+      "value": "georgian",
+      "definition": "A restaurant specializing in Georgian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "german",
+      "definition": "An establishment specializing in German cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "german.baden",
+      "definition": "A restaurant specializing in the cuisine from Baden, a region of southwestern Germany."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.bavarian",
+      "definition": "A restaurant specializing in the regional cuisine of Bavaria."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.currysausage",
+      "definition": "An establishment specializing in curried sausage, also known as Currywurst"
+    },
+    {
+      "feature": "occupant",
+      "value": "german.easterngerman",
+      "definition": "A restaurant specializing in Eastern German cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.fischbroetchen",
+      "definition": "An establishment specializing in a fish sandwich made with other components like fresh white or dried onions, pickles, remoulade, creamy horseradish sauce, ketchup, or cocktail sauce"
+    },
+    {
+      "feature": "occupant",
+      "value": "german.franconian",
+      "definition": "A restaurant offering Franconian cuisine (German)."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.hessian",
+      "definition": "A restaurant specialized in cuisine from the German region of Hesse, which includes both the State of Hesse and the area known as Rhenish Hesse."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.heuriger",
+      "definition": "Eastern Austrian wine taverns in which specially licensed local winemakers serve their most recent year's wines for short periods following the growing season. They are renowned for their atmosphere of Gemütlichkeit (a space of warmth, friendliness, and good cheer) shared among a throng enjoying young wine, simple food, and traditional music."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.northerngerman",
+      "definition": "A restaurant specializing in Northern German cuisine, with dishes centered around boiled potatoes, rye bread, dairy products, cabbages, cucumbers, berries, jams, fish, and pork and beef."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.palatine",
+      "definition": "A restaurant specializing in the cuisine of the Palatinate, a region in Southwestern Germany occupying more than a quarter of the German federal state of Rhineland-Palatinate."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.rhinelandian",
+      "definition": "A restaurant specializing in the cuisine of the Rhineland, a region in Western Germany along the Middle and Lower Rhine."
+    },
+    {
+      "feature": "occupant",
+      "value": "german.swabian",
+      "definition": "A restaurant specializing in the preparation of cuisine from the region of Swabia in southwestern Germany."
+    },
+    {
+      "feature": "occupant",
+      "value": "giblets",
+      "definition": "A food establishment specialized in the preparation of dishes featuring the organ meats of fowl, typically including the heart, gizzard, liver, and other visceral organs."
+    },
+    {
+      "feature": "occupant",
+      "value": "giftshops",
+      "definition": "A business specializing in in the sale of small gifts and presents"
+    },
+    {
+      "feature": "occupant",
+      "value": "glutenfree",
+      "definition": "An establishment specializing in cuisine that does not include gluten"
+    },
+    {
+      "feature": "occupant",
+      "value": "gokarting",
+      "definition": "Facilities for racing go-karts, small four-wheeled vehicles usually raced around outdoor tracks."
+    },
+    {
+      "feature": "occupant",
+      "value": "goldmerchants",
+      "definition": "A business that purchases gold from customers for cash. May also accept other precious metals too."
+    },
+    {
+      "feature": "occupant",
+      "value": "golf",
+      "definition": "Used for golf courses. For golf stores, use shopping.golfshops. For driving ranges, use active.golf.drivingrange."
+    },
+    {
+      "feature": "occupant",
+      "value": "golf.instruction",
+      "definition": "Businesses or individuals that provide golf lessons."
+    },
+    {
+      "feature": "occupant",
+      "value": "golfequipment",
+      "definition": "A store offering golf equipment such as clubs, apparel, and shoes"
+    },
+    {
+      "feature": "occupant",
+      "value": "golfshop",
+      "definition": "A store offering golf equipment such as clubs, apparel, and shoes"
+    },
+    {
+      "feature": "occupant",
+      "value": "gourmetfood",
+      "definition": "Stores or businesses that sell specialized or uncommon foods."
+    },
+    {
+      "feature": "occupant",
+      "value": "gourmetmarket",
+      "definition": "Markets that specialize in the sale of fresh produce and fruits."
+    },
+    {
+      "feature": "occupant",
+      "value": "graphicaldesign",
+      "definition": "A person or business who offers skills in creating images and text to be used in advertising and illustrations."
+    },
+    {
+      "feature": "occupant",
+      "value": "greek",
+      "definition": "An establishment specializing in Greek cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "grillingequipment",
+      "definition": "A store that primarily sells grilling equipment, including grilling tools, utensils, and grill sets."
+    },
+    {
+      "feature": "occupant",
+      "value": "grocery"
+    },
+    {
+      "feature": "occupant",
+      "value": "grocery.asian",
+      "definition": "A grocery store specialized in more than one type of Asian products such that it cannot be classified under a more specific category such as Chinese Grocery or Japanese Grocery."
+    },
+    {
+      "feature": "occupant",
+      "value": "grocery.chinese",
+      "definition": "Grocery stores specializing in the sale of groceries and household goods imported from China"
+    },
+    {
+      "feature": "occupant",
+      "value": "grocery.indian",
+      "definition": "Grocery stores specializing in the sale of groceries and household goods imported from India"
+    },
+    {
+      "feature": "occupant",
+      "value": "grocery.japanese",
+      "definition": "Grocery stores specializing in the sale of groceries and household goods imported from Japan"
+    },
+    {
+      "feature": "occupant",
+      "value": "grocery.korean",
+      "definition": "Grocery stores specializing in the sale of groceries and household goods imported from Korea"
+    },
+    {
+      "feature": "occupant",
+      "value": "grocery.persian",
+      "definition": "Grocery stores specializing in the sale of groceries and household goods imported from Iran"
+    },
+    {
+      "feature": "occupant",
+      "value": "grocerystore",
+      "definition": "Businesses that specialize in the sale of food and household supplies."
+    },
+    {
+      "feature": "occupant",
+      "value": "guitarstore",
+      "definition": "A store specialized in guitar sales and rentalservices."
+    },
+    {
+      "feature": "occupant",
+      "value": "gunrange",
+      "definition": "Facilities dedicated to the practice of shooting riles and other firearms."
+    },
+    {
+      "feature": "occupant",
+      "value": "gunsandammo",
+      "definition": "A business specializing in firearms, ammunition and associated paraphernalia"
+    },
+    {
+      "feature": "occupant",
+      "value": "gym",
+      "definition": "Facilities housing gym equipment such as treadmills and dumbbells for independent exercise. Do not use for individuals providing gym training programs; gyms with prominent trainer programs may be marked \"Trainers\" as well as \"Gyms.\""
+    },
+    {
+      "feature": "occupant",
+      "value": "gymnastics",
+      "definition": "Gyms or other facilities where the sport of gymnastics is practiced and taught. Can be used for individual or group teaching environments."
+    },
+    {
+      "feature": "occupant",
+      "value": "hairblowout",
+      "definition": "Businesses that specialize in blow drying hair. Do not use for general hair salons that provide haircuts and coloring."
+    },
+    {
+      "feature": "occupant",
+      "value": "haircutsstyling",
+      "definition": "Businesses that specialize in haircuts, hair styling, and hair coloring."
+    },
+    {
+      "feature": "occupant",
+      "value": "haircutsstyling.mens",
+      "definition": "Businesses specializing in men's haircuts in a salon atmosphere, who tend to be more exepensive than barbers."
+    },
+    {
+      "feature": "occupant",
+      "value": "hairextensions",
+      "definition": "Businesses offering hair extensions and treatment for hair extensions. As a child category of hair salons, hair salons also offering hair extensions can have this added as their biz attribute, but not as a category."
+    },
+    {
+      "feature": "occupant",
+      "value": "hairloss",
+      "definition": "Medical facilities that focus on the treatment of hair loss, including transplantation and replacement."
+    },
+    {
+      "feature": "occupant",
+      "value": "hairremoval",
+      "definition": "Businesses that specialize in the removal of facial or body hair through waxing or threading methods."
+    },
+    {
+      "feature": "occupant",
+      "value": "hairremoval.laser",
+      "definition": "Businesses that specialize in the removal of facial or body hair through waxing or light-based methods."
+    },
+    {
+      "feature": "occupant",
+      "value": "hairremoval.threading"
+    },
+    {
+      "feature": "occupant",
+      "value": "hairremoval.waxing",
+      "definition": "Businesses that specialize in the removal of hair using wax."
+    },
+    {
+      "feature": "occupant",
+      "value": "hairstylist",
+      "definition": "Individuals who rent chairs in salon spaces."
+    },
+    {
+      "feature": "occupant",
+      "value": "haitian",
+      "definition": "An establishment specializing in Hatian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "halal",
+      "definition": "An establishment serving food that is in line with Islamic food practices."
+    },
+    {
+      "feature": "occupant",
+      "value": "hardware",
+      "definition": "A business that sells tools and supplies associated with both commercial operations and home improvement projects."
+    },
+    {
+      "feature": "occupant",
+      "value": "hats",
+      "definition": "Businesses that sell items people wear on their heads"
+    },
+    {
+      "feature": "occupant",
+      "value": "hauntedhouse"
+    },
+    {
+      "feature": "occupant",
+      "value": "hawaiian",
+      "definition": "An establishment specializing in Hawaiian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "headshop",
+      "definition": "A shop focusing on marijuana and related paraphernalia"
+    },
+    {
+      "feature": "occupant",
+      "value": "healthcare"
+    },
+    {
+      "feature": "occupant",
+      "value": "healthcarecenter",
+      "definition": "Any facility/service providing health care but that do not fit other categories such as hospitals, emergency rooms, rehabilitation center, medical center, medical office, hospital department, long term care facility or medical research institute."
+    },
+    {
+      "feature": "occupant",
+      "value": "healthyfoods",
+      "definition": "Businesses that sell health-conscious foods and goods, such as dietary supplements and organic, non-processed foods."
+    },
+    {
+      "feature": "occupant",
+      "value": "hearingaidproviders",
+      "definition": "Businesses providing hearing tests, selections of hearing aids, and/or hearing aid fittings."
+    },
+    {
+      "feature": "occupant",
+      "value": "hearingaids",
+      "definition": "A business specializing in a devices for assisting the hearing of partially deaf people, typically consisting of a small battery-powered electronic amplifier with microphone and earphone, worn by a deaf person in or behind the ear."
+    },
+    {
+      "feature": "occupant",
+      "value": "hennaartist",
+      "definition": "Individuals specializing in the creation of artistic designs on the skin using henna ink to create a type of temporary tattoo."
+    },
+    {
+      "feature": "occupant",
+      "value": "herbalmedicine",
+      "definition": "A business that primarily sells herbs, herbal medicine, and herbal products. In Chinese herbal shops, there are often traditional Chinese medicine practitioners on site. Not to be confused with Herbs & Spices, which is for shops that sell herbs used for cooking."
+    },
+    {
+      "feature": "occupant",
+      "value": "herbsandspices",
+      "definition": "Businesses that specialize in the sale of herbs and spices used for cooking."
+    },
+    {
+      "feature": "occupant",
+      "value": "highschool",
+      "definition": "Second schools for individuals, generally for grades 6-12 and ages 12-18."
+    },
+    {
+      "feature": "occupant",
+      "value": "himalayan",
+      "definition": "An establishment specializing in Himalayan/Nepalese cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "hobbyshop",
+      "definition": "Specialist stores for recreational hobbies. Examples include model trains, diecast collectables, building kits, paints, collectable dolls, statues, action figures, electronic sets, remote control cars, and so on. These businesses may sell items or accessories tied to creating and modifying these items themselves."
+    },
+    {
+      "feature": "occupant",
+      "value": "holidaydecorations"
+    },
+    {
+      "feature": "occupant",
+      "value": "homeandgarden"
+    },
+    {
+      "feature": "occupant",
+      "value": "homeappliancerepair",
+      "definition": "A business that provides services for household appliances such as delivery, sale, installation and/or repair."
+    },
+    {
+      "feature": "occupant",
+      "value": "homeautomation",
+      "definition": "A business or individual with expertise in electrical and computer systems that control and integrate home features such as lights, audio, thermostats, appliances and security."
+    },
+    {
+      "feature": "occupant",
+      "value": "homecleaning",
+      "definition": "Businesses that provide cleaning and detailing services for residential and commercial properties including housekeepers and maids. Should not be considered for businesses that fall under damage restoration."
+    },
+    {
+      "feature": "occupant",
+      "value": "homedecor",
+      "definition": "A business selling decorative items for a house. Items like lights, pillows, art, vases, curtains, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "homedevelopers",
+      "definition": "A business that specializes in building single-family residences in large-scale, master-planned communities. Some of these companies will sell the individual homes directly and manage the common areas within the built community. Some home developers will merely build the community on behalf of another company."
+    },
+    {
+      "feature": "occupant",
+      "value": "homegarden",
+      "definition": "Businesses that sell items designed for use in the home or in the garden"
+    },
+    {
+      "feature": "occupant",
+      "value": "homehealthcare",
+      "definition": "Health care or medical treatment provided on an ongoing basis in the patient's home, i.e. concierge services provided by doctors and nurses who visit the homes of patients."
+    },
+    {
+      "feature": "occupant",
+      "value": "homeopathy",
+      "definition": "Store that specializes in the sales of homeopathy medicines. Not to the be confused with health.physicians.homeopathic for the practitioner of Homeopathic medicine."
+    },
+    {
+      "feature": "occupant",
+      "value": "hometheaterinstallation",
+      "definition": "A business or individual with expertise in the set up and installation of audio and visual equipment, re-creating a 'movie theater' experience at home."
+    },
+    {
+      "feature": "occupant",
+      "value": "honey",
+      "definition": "A business specializing in a sweet, viscid fluid produced by bees from the nectar collected from flowers."
+    },
+    {
+      "feature": "occupant",
+      "value": "hongkong.cafe",
+      "definition": "Also known as a cha chaan teng or tea restaurant, Hong Kong cafes are simple, quick service restaurants known for eclectic and affordable menus, which include dishes from Hong Kong cuisine and Hong Kong-style Western cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "hookahbar",
+      "definition": "A bar that offers a hookah pipes to smoke flavored tobacco"
+    },
+    {
+      "feature": "occupant",
+      "value": "horsequipment",
+      "definition": "A business selling items related to the feeding and care of horses"
+    },
+    {
+      "feature": "occupant",
+      "value": "hospital",
+      "definition": "Business providing a variety of forms of medical assistance, most commonly emergency services, surgical procedures, and psychiatric evaluation."
+    },
+    {
+      "feature": "occupant",
+      "value": "hostel",
+      "definition": "An inexpensive accommodation with shared and/or private rooms offering some guest related services and shared facilities like kitchens or game rooms."
+    },
+    {
+      "feature": "occupant",
+      "value": "hotdogs",
+      "definition": "An establishment that sells hot dogs"
+    },
+    {
+      "feature": "occupant",
+      "value": "hotel",
+      "definition": "Businesses providing short-term lodging, that typically have a staff that cleans and maintains rooms for its guests."
+    },
+    {
+      "feature": "occupant",
+      "value": "hotel.business",
+      "definition": "A commercial establishment providing lodging, meals, and other guest services that caters to business people."
+    },
+    {
+      "feature": "occupant",
+      "value": "hotel.capsule",
+      "definition": "A capsule hotel (カプセルホテル kapuseru hoteru), also known as a pod hotel, is a type of hotel developed in Japan that features a large number of extremely small \"rooms\" (capsules) intended to provide cheap, basic overnight accommodation for guests who do not require or who cannot afford the services offered by more conventional hotels."
+    },
+    {
+      "feature": "occupant",
+      "value": "hotelbar",
+      "definition": "An establishment that is located in a hotel and serves alcoholic beverages, such as beer, wine, liquor, cocktails, and other beverages."
+    },
+    {
+      "feature": "occupant",
+      "value": "hotpot",
+      "definition": "An establishment offering food in the traditional asian style known as hot pot. All ingredient are cooked single hot pot, usually by the customer at their table. The restaurant will provide the raw ingredients for the customer to cook themselves."
+    },
+    {
+      "feature": "occupant",
+      "value": "hottubandpool",
+      "definition": "A business that primarily sells pools, hot tubs, spas, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "housingcooperative",
+      "definition": "A type of housing tenure where an association or corporation owns a group of housing units and the common areas for the use of all the residents. The individual participants own a share in the cooperative which entitles them to occupy an apartment (or town house) as if they were owners, to have equal access to the common areas, and to vote for members of the Board of Directors which manages the cooperative."
+    },
+    {
+      "feature": "occupant",
+      "value": "hungarian",
+      "definition": "An establishment specializing in Hungarian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "huntingfishingsupplies",
+      "definition": "A business that primarily sells fishing and hunting equipment (fishhooks, fishing rods, baits, rifles, cartridges, knives etc.)."
+    },
+    {
+      "feature": "occupant",
+      "value": "hvac",
+      "definition": "A business or individual providing services related to ventilation, heating or air conditioning systems such as installation and repair."
+    },
+    {
+      "feature": "occupant",
+      "value": "hypermarket",
+      "definition": "In commerce, a hypermarket is a superstore combining a supermarket and a department store. The result is an expansive retail facility carrying a wide range of products under one roof, including full groceries lines and general merchandise"
+    },
+    {
+      "feature": "occupant",
+      "value": "iberian",
+      "definition": "An establishment specializing in Iberian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "icecream",
+      "definition": "Businesses that specialize in the sale of frozen yogurt and ice cream."
+    },
+    {
+      "feature": "occupant",
+      "value": "importedfood",
+      "definition": "A store that primarily sells imported foods from a particular country/region such as canned foods, confections, candies, snacks, spices, jams, oils, cured meats, beverages, etc. These shops typically do not carry fresh produce/meats or a wide range of non-food items like a grocery shop does."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian",
+      "definition": "Restaurant specializing in Indian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.andhra",
+      "definition": "An eatery/restaurant offering Andhra food, with a good balance between vegetarian and non-vegetarian fare. Characterized by its unique tanginess and spiciness, popular food items include Gongura Mamsam, Pulihora, Pulusu, and Podi along with an assortment of pickles."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.assamese",
+      "definition": "Restaurants serving assamese cuisine have generous portions of white rice, lentils, elephant apple curries, khaar, indigenous pickles, fried potatoes, fried fish and fish curry in its classic sour flavour, (roasted duck or pigeon is also an option sometimes)."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.awadhi",
+      "definition": "An eatery specializing in Awadhi Cuisine, influenced largely by Central Asian and Middle Eastern cuisines. Famous for its kebabs, popular dishes include Kakori Kebabs, Galawti Kebabs, Seekh Kebabs and Awadhi Biryani."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.bihari",
+      "definition": "Cuisine from the Indian state of Bihar."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.chettinad",
+      "definition": "A restaurant serving Chettinad cuisine has a variety of dishes cooked in freshly ground spices and curry leaves; These dishes are mostly served with rice, dosais, idlis and idiappams (all prepared from rice)."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.goan",
+      "definition": "Restaurants specializing in Goan cuisine, with a good mix of seafood, poultry and red meat. Popular dishes include Pork Vindaloo, Goan Prawn curry and the famous Goan dessert - Bibingka."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.gujarat",
+      "definition": "Cuisine from western India state of Gujarat."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.hyderabadi",
+      "definition": "Restaurants specializing in Hyderabadi cuisine; famous for “Hyderabadi Biryani” which traditionally has lamb as its base. Other variants of the Hyderabadi Biryani include Chicken and Prawn. Hyderabadi cuisine is also famous for desserts such as Qubani ka Meetha and Firni."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.kerala",
+      "definition": "A restaurant serving Kerala food is heavy on dishes with coconut as its base for curry. Most Kerala dishes are meat and seafood oriented. Mildly spiced dishes like meen moilee to very spicy dishes like kozhi vevichathu are served at almost all establishments (big and small)."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.konkan",
+      "definition": "A restaurant serving Konkan cuisine, a conflation of cuisines from the western coastal belt of India. Heavily seasoned with different forms of coconut, Konkani fare served in restaurants are known to be spicy."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.lucknowi",
+      "definition": "A restaurant serving food which is largely influenced by the kitchens of the Nawabs of Lucknow. Popular dishes include murgh musallam, boti kebabs, warqi parantha and desserts such as Shahi Tukda."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.maharashtrian",
+      "definition": "A restaurant serving Maharashtrian fare which is largely vegetarian. Most restaurants serve the popular bhakri, vada pav, misal pav and the amti - a dish accompanied with steamed rice"
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.malwani",
+      "definition": "An establishment which specializes in food from the western coastal area of India. Preparations are generally spicy with the usage of dried red chilies, peppercorns, coconut, tamarind and kokum. Popular dishes include sol kadhi, bombay duck and spicy curries served with rice."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.mangalorean",
+      "definition": "An eatery focusing on Mangalorean cuisine, which is a mix of sea-food and poultry. Most dishes are coconut based and dry red chillies are used to spice them. Rice and buttermilk are typical accompaniments for Mangalorean food."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.northindian",
+      "definition": "Restaurant specializing in the cuisine of northern India."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.oriya",
+      "definition": "A restaurant serving Odia cuisine is mild on the spice front and extreme on flavours. Coconut and mustard oil are primary ingredients in Odiya cooking. The coastal region has a variety of fish, mutton (maangsa jhola) prawns and lobster cooked in spices. Pakhala (cooked rice soaked in water overnight and seasoned with salt, curd and green chillies) is synonymous to Odia cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.rajasthani",
+      "definition": "Characterized by strong and fiery flavors, Rajasthani fare includes dishes such as Daal Baati Churma, Lal Maas and Gatte ki Sabzi. Most Rajasthani restaurants are also famous for their elaborate thalis filled with rice, roti, curry, sabzis (vegetable preparations) and finally desserts, comprising Rajasthani sweets."
+    },
+    {
+      "feature": "occupant",
+      "value": "indian.southindian",
+      "definition": "Restaurant specializing in the cuisine of southern India."
+    },
+    {
+      "feature": "occupant",
+      "value": "indonesian",
+      "definition": "An establishment specializing in Indonesian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "informationtechnology",
+      "definition": "A business or individual that specializes in information technology and computer related services including troubleshooting, web design, and device repair and set-up."
+    },
+    {
+      "feature": "occupant",
+      "value": "installmentloanservices",
+      "definition": "A business that provides installment loans, which are loans that are repaid over time with a set number of scheduled payments. The term of loan may be as little as a few months and as long as 30 years. Compared to payday loans, installment loans typically have bigger amounts, lower interest and fees, and longer payback times and are usually secured by collateral such as personal property. Mortgages, small biz loans, and student loans are all examples of installment loans."
+    },
+    {
+      "feature": "occupant",
+      "value": "insulationinstallation",
+      "definition": "A business or individual that provides insulation related services."
+    },
+    {
+      "feature": "occupant",
+      "value": "insurance",
+      "definition": "Businesses or individuals representing businesses providing indemnity or financial protection for individuals or their goods."
+    },
+    {
+      "feature": "occupant",
+      "value": "insurance.auto",
+      "definition": "Businesses or individuals representing businesses providing auto insurance."
+    },
+    {
+      "feature": "occupant",
+      "value": "insurance.health",
+      "definition": "Offices of health insurance companies where clients can receive customer support."
+    },
+    {
+      "feature": "occupant",
+      "value": "insurance.home",
+      "definition": "Businesses or individuals representing businesses providing home and/or rentalservices insurance."
+    },
+    {
+      "feature": "occupant",
+      "value": "insurance.life",
+      "definition": "Businesses or individuals representing businesses providing life insurance."
+    },
+    {
+      "feature": "occupant",
+      "value": "interiordesign",
+      "definition": "A business or individual that coordinates and manages the design and decoration of the interior spaces of residential and commercial properties."
+    },
+    {
+      "feature": "occupant",
+      "value": "internalmedicine",
+      "definition": "Doctors specializing in the diagnosis and non-invasive treatment of illness."
+    },
+    {
+      "feature": "occupant",
+      "value": "internationalfood",
+      "definition": "A restaurant or eatery featuring cuisines from all over the world."
+    },
+    {
+      "feature": "occupant",
+      "value": "internetbooth",
+      "definition": "Free-standing structures intended to provide public internet access and are analogous to payphones for telephone service."
+    },
+    {
+      "feature": "occupant",
+      "value": "internetcafe",
+      "definition": "Businesses providing computers for Internet access for a fee, that may also serve food and beverages."
+    },
+    {
+      "feature": "occupant",
+      "value": "internetserviceprovider",
+      "definition": "Companies and other organizations that provide internet services and connections to residential and commercial properties."
+    },
+    {
+      "feature": "occupant",
+      "value": "investmentbanking",
+      "definition": "Businesses that specialize in investing money on behalf of clients."
+    },
+    {
+      "feature": "occupant",
+      "value": "irish",
+      "definition": "An establishment specializing in Irish cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "irishpub",
+      "definition": "A venue where their primary business is serving alcohol and food in a Irish setting."
+    },
+    {
+      "feature": "occupant",
+      "value": "israeli",
+      "definition": "A food establishment specializing in Israeli cuisine, a cuisine giving prominence to foods common in the Mediterranean region such as olives, chickpeas, dairy products, fish, and fresh fruits and vegetables but also influenced by the culinary traditions of the global Jewish diaspora now residing in Israel."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian",
+      "definition": "An establishment specializing in Italian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.abruzzese",
+      "definition": "A restaurant specializing in the cuisine of Abruzzo, a region of central Italy bordering the Adriatic sea and known for its diverse cuisine of both coastal and agricultural influences."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.altoatesine",
+      "definition": "A restaurant specializing in the cuisine of South Tyrol, a German speaking region in Northern Italy. Alto Adige dishes are often hearty and include goulashes and cornmeal polenta, dumplings served with meat, as well as different types of pastas."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.apulian",
+      "definition": "A restaurant specializing in the cuisine of Apulia, a coastal region of Southern Italy. Some of the key ingredients to Apulian dishes include olive oil, artichokes, tomatoes, and mushrooms."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.calabrian",
+      "definition": "An establishment specializing in Calabrian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.cucinacampana",
+      "definition": "A restaurant specializing in the cuisine of Campania, a region in southern Italy, which may include pizzas, spaghettis, and other dishes relying on cheeses and fresh vegetables as well as seafood. Restaurants primarily focused on the cuisine of Naples should be listed under the Neapolitan category."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.diner",
+      "definition": "A very informal, usually small (and sometimes self-serve) food establishment offering hot and cold food that is often eaten at the counter, even though many places have tables as well. Besides the traditional Italian bar/caf_ fare (bar/caf_ as it is intended in Italy, a place selling pastries, latte, coffee, tea, etc. not food as you could have at a \"Caf_\" in the US), a tavola calda can serve lunch or dinner often showcasing local food, with more elaborate dishes (some of which are reheated to order) than just sandwiches or snacks. A tavola calda has a full-blown kitchen and has to comply with the health department regulations just like a regular restaurant. A tavola calda can also serve rotisserie chicken, rustic pies, pizza by the slice, and salads."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.emilian",
+      "definition": "A restaurant specializing in the cuisine of the Emilia-Romagna region of Italy, known for its egg and filled pasta made with soft wheat flour and dishes including tortellini, lasagne, gramigna and tagliatelle."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.friulan",
+      "definition": "A restaurant specializing in the cuisine of Friuli, a region of northeast Italy with stronger Central European and Slavic influences. The cuisine includes greater use of goulash, sauerkraut, sausages, potatoes and turnips than other Italian cuisines."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.lumbard",
+      "definition": "A restaurant specializing in the regional cuisine of Lombardy, heavily based upon ingredients like maize, rice, beef, pork, butter, and lard."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.napoletana",
+      "definition": "A restaurant specializing in Neapolitan cuisine, combining dishes based on rural ingredients (pasta, vegetables, cheese) and seafood dishes (fish, crustaceans, mollusks)."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.norcinerie",
+      "definition": "A food establishment which serves and/or sells pig products utilizing the art of processing pork and related techniques that come from the town of Norcia, in the province of Perugia, Italy"
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.piedmont",
+      "definition": "A restaurant specializing in the gastronomy of the region of Piedmont in northern Italy."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.roman",
+      "definition": "A restaurant specializing in the cuisine of Rome, which utilizes seasonal ingredients from the surrounding Roman Campagna region with preparation in a simple manner."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.sardinian",
+      "definition": "An establishment specializing in Sardinian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.sicilian",
+      "definition": "A restaurant specializing in the cuisine of Sicily, an Italian island in the Mediterranean Sea. While having a lot in common with Italian cuisine, Sicilian food also has Greek, Spanish, French and Arab influences."
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.tuscan",
+      "definition": "An establishment specializing in Tuscan cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "italian.venetian",
+      "definition": "A restaurant specializing in the cuisine of Venice and the surrounding region of Veneto in Italy."
+    },
+    {
+      "feature": "occupant",
+      "value": "ivhydration"
+    },
+    {
+      "feature": "occupant",
+      "value": "izakaya",
+      "definition": "A type of informal Japanese gastropub, generally offering a slow pace of food ordering and serving and are casual places for after-work drinking."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese",
+      "definition": "An establishment specializing in Japanese cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.bento",
+      "definition": "A food establishment offering Japanese single-portion takeout or home-packed meals. Bentos traditionally hold rice, fish or meat, with pickled or cooked vegetables, and are usually served in a box-shaped container."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.blowfish",
+      "definition": "A restaurant specializing in the preparation of blowfish or fugu, a meat that must be carefully prepared to remove the toxic parts and avoid potentially lethal contamination."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.curry",
+      "definition": "A food establishment specializing in Japanese styles of curry and served in three main forms: curry rice, curry udon, and curry bread."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.donburi",
+      "definition": "A food establishment specializing in donburi, a Japanese \"rice bowl dish\" consisting of fish, meat, vegetables or other ingredients simmered together and served over rice."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.gyudon",
+      "definition": "A food establishment specializing in gyudon, a Japanese dish consisting of a bowl of rice topped with beef and onion simmered in a mildly sweet sauce."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.handrolls",
+      "definition": "A food establishment specializing in temaki sushi or hand rolls, a type of sushi often made at home and consists of a rolled cone of seaweed, wrapped around rice and fillings."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.horumon",
+      "definition": "A food establishment specializing in horumon, a kind of Japanese cuisine made from beef or pork offal (organ meats)."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.kushikatsu",
+      "definition": "A food establishment specializing in Kushikatsu, a Japanese dish of deep-fried skewered meat and vegetables."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.nikkei",
+      "definition": "A restaurant that specializes in Nikkei cuisine, a Japanese-Peruvian fusion cuisine (and to a lesser extender, Brazilian-Japanese). It is most popular in South America and Spain and transforms Peruvian dishes using Japanese flavors and techniques and vice versa."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.oden",
+      "definition": "A food establishment specializing in oden, a Japanese winter dish consisting of several ingredients such as boiled eggs, daikon, konjac, and processed fishcakes stewed in a light, soy-flavoured dashi broth."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.okonomiyaki",
+      "definition": "A food establishment specializing in Okonomiyaki, a Japanese savory pancake containing a variety of ingredients."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.onigiri",
+      "definition": "A food establishment specializing in o-nigiri. Also known as o-musubi, nigirimeshi or rice ball, onigiri is a Japanese food made from white rice formed into triangular or cylinder shapes, filled with pickled ume, salted salmon, katsuobushi, or any other salty or sour ingredient, and often wrapped in nori (seaweed)."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.oyakodon",
+      "definition": "A food establishment specializing in oyakodon, a Japanese rice bowl dish, in which chicken, egg, sliced scallion (or sometimes regular onions), and other ingredients are all simmered together in a sauce and then served on top of a large bowl of rice."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.ramen",
+      "definition": "An establishment specializing in Ramen"
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.shabushabu",
+      "definition": "A Japanese nabemono hotpot dish of thinly sliced meat and vegetables boiled in water."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.soba",
+      "definition": "A food establishment specializing in soba, a type of Japanese thin noodle made from buckwheat flour and served either chilled with a dipping sauce, or in hot broth as a noodle soup."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.sukiyaki",
+      "definition": "A food establishment specializing in sukiyaki, a Japanese dish that is prepared and served in the nabemono (Japanese hot pot) style."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.takoyaki",
+      "definition": "A food establishment specializing in takoyaki, a ball-shaped Japanese snack made of a wheat flour-based batter, often filled with minced octopus and cooked in a special takoyaki pan."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.tempura",
+      "definition": "A food establishment specializing in tempura, a Japanese dish of seafood or vegetables that have been battered and deep fried."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.teppanyaki",
+      "definition": "An establishment specializing in food cooked on iron griddle. Typically the food is cooked at the customer table by a chef. The food is western influenced Japanese, also referred to as Hibachi."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.tonkatsu",
+      "definition": "A food establishment specializing in tonkatsu, a Japanese style fried pork cutlet."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.udon",
+      "definition": "A food establishment specializing in udon, type of Japanese thick wheat flour noodle often served hot as noodle soup."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.unagi",
+      "definition": "A food establishment specializing in the preperation of ungai or freshwater eel"
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.westernjapanese",
+      "definition": "A food establishment specializing in Japanese cuisine that has been influenced by western culinary techniques and ingredients."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.yakiniku",
+      "definition": "A food establishment specializing in yakiniku, a Japanese style of grilled meats."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanese.yakitori",
+      "definition": "A food establishment specializing in yakitori, a Japanese style of grilled chicken."
+    },
+    {
+      "feature": "occupant",
+      "value": "japanesesweets",
+      "definition": "A business specializing in Japanese desserts and sweet goods."
+    },
+    {
+      "feature": "occupant",
+      "value": "jewelry",
+      "definition": "A specialist shop selling jewelry. May offer custom made jewelry."
+    },
+    {
+      "feature": "occupant",
+      "value": "jewelryrepair",
+      "definition": "A business or individual specialized in jewelry repair and restoration. Should not be applied to watch repair services."
+    },
+    {
+      "feature": "occupant",
+      "value": "jewish",
+      "definition": "A restaurant specializing in any of the diverse collection of cooking traditions of the Jewish diaspora worldwide. Restaurants and eateries serving kosher foods but not specialized in Jewish gastronomy should be listed with the kosher category instead."
+    },
+    {
+      "feature": "occupant",
+      "value": "juicebar",
+      "definition": "Businesses that specialize in the sale of smoothies and fruit and vegetable juices."
+    },
+    {
+      "feature": "occupant",
+      "value": "kaiseki",
+      "definition": "A restaurant serving meals in the style of kaiseki, a traditional multi-course Japanese dinner. Kaiseki is analogous to Western haute cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "karaoke",
+      "definition": "Karaoke is the singing of popular songs with prerecorded backing tracks, this may be in private rooms or in front of an audience"
+    },
+    {
+      "feature": "occupant",
+      "value": "kashmiri",
+      "definition": "Eateries serving Kashmiri food, characterized by mild spices and rich flavors with a variety of meat preparations. Popular dishes include Rogan Josh, Yakhni and Dum Aloo. Equally popular is the Kahwah - a green tea made with saffron, spices and walnuts."
+    },
+    {
+      "feature": "occupant",
+      "value": "kebab",
+      "definition": "Any restaurant or eatery specializing in kebabs, typically consisting of grilled meats prepared for a variety dishes of Middle East and Central Asian origin."
+    },
+    {
+      "feature": "occupant",
+      "value": "kidsactivities",
+      "definition": "Outdoor and indoor establishments offering play activities for children."
+    },
+    {
+      "feature": "occupant",
+      "value": "kimonos",
+      "definition": "A store that sells traditional Japanese garments called Kimonos."
+    },
+    {
+      "feature": "occupant",
+      "value": "kindergarten",
+      "definition": "A kindergarten is a preschool educational approach traditionally based on playing, singing, practical activities such as drawing, and social interaction as part of the transition from home to school. In Japan, it is governed by the Ministry of Education, Culture, Sports, Science and Technology is run 4 hours a day for children ages 3-6."
+    },
+    {
+      "feature": "occupant",
+      "value": "kiosk"
+    },
+    {
+      "feature": "occupant",
+      "value": "kiosk.food",
+      "definition": "A booth with an open window on one side selling small, inexpensive consumables."
+    },
+    {
+      "feature": "occupant",
+      "value": "kitchenandbath",
+      "definition": "A business that sells items related to kitchens and bathrooms. This includes fixtures and faucets, appliances and hardware, as well as items used in those two spaces."
+    },
+    {
+      "feature": "occupant",
+      "value": "kitchenincubator",
+      "definition": "Shared kitchen facilities available for rent and generally utilized by caterers and other food preparation and production companies that lack their own kitchen facilities."
+    },
+    {
+      "feature": "occupant",
+      "value": "knifesharpening",
+      "definition": "A business or individual providing knife sharpening services."
+    },
+    {
+      "feature": "occupant",
+      "value": "knittingsupplies",
+      "definition": "A shop that specializes in all thing knitting: yarn, needles, sewing patterns"
+    },
+    {
+      "feature": "occupant",
+      "value": "kopitiam",
+      "definition": "A traditional coffee shop found in Southeast Asia and patronized for meals and beverages. Menus typically feature simple offerings: a variety of foods based on egg, toast, and kaya, plus coffee, tea, and Milo, a malted chocolate drink. The kopi (coffee) is the specialty and can be ordered in a variety of ways, including extra thick, extra thin or with condensed milk."
+    },
+    {
+      "feature": "occupant",
+      "value": "korean",
+      "definition": "An establishment specializing in Korean cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "kosher",
+      "definition": "An establishment serving food that is in line with Jewish food practices."
+    },
+    {
+      "feature": "occupant",
+      "value": "kurdish",
+      "definition": "A restaurant specializing in the cuisine prepared by the people of Kurdistan. Staples of Kurdish cuisine include berbesel, biryani, dokliw, kullerenaske, kutilk, kuki, birinç, and a variety of salads, pastries, and drinks specific to different parts of Kurdistan."
+    },
+    {
+      "feature": "occupant",
+      "value": "laboratorytesting",
+      "definition": "Medical businesses that specialize in testing samples from people, such as of blood and urine."
+    },
+    {
+      "feature": "occupant",
+      "value": "landmark",
+      "definition": "Items in this category are spaces and places of significance and history."
+    },
+    {
+      "feature": "occupant",
+      "value": "landscaping",
+      "definition": "A licensed professional the designs and develops the landscapes of residential and/or commercial properties."
+    },
+    {
+      "feature": "occupant",
+      "value": "languageschool",
+      "definition": "Schools that specialize in providing formal exposure to foreign languages, or in the refinement of native languages."
+    },
+    {
+      "feature": "occupant",
+      "value": "laotian",
+      "definition": "A restaurant specializing in the cuisine of Laos."
+    },
+    {
+      "feature": "occupant",
+      "value": "lasereyesurgery",
+      "definition": "Doctors or medical practices that perform laser eye surgery (Lasik), a procedure that reshapes the cornea and reduces the need for glasses. Most often performed by an ophthalmologist."
+    },
+    {
+      "feature": "occupant",
+      "value": "lasertag",
+      "definition": "Businesses or facilities where laser tag is played, indoor and outdoor recreational activity where players attempt to score points by tagging targets with hand-held infrared devices."
+    },
+    {
+      "feature": "occupant",
+      "value": "latinamerican",
+      "definition": "An establishment specializing in Latin American cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "laundromat",
+      "definition": "A fully automated and coin-operated facility where clothes are washed and dried."
+    },
+    {
+      "feature": "occupant",
+      "value": "laundryservices",
+      "definition": "Businesses or locations that offer dry cleaning and laundry services or have laundry machines available for individual use."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer",
+      "definition": "An individual or business that practices law. If possible please put the business in specialized sub categories rather than this generic category"
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.business",
+      "definition": "A lawyer or law firm with expertise in legal aspects of conducting business."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.criminaldefense",
+      "definition": "A lawyer or law firm with expertise in criminal defense."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.divorce",
+      "definition": "A lawyer or law firm with expertise in divorce proceedings and other family law areas"
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.estateplanning",
+      "definition": "A lawyer or law firm with expertise in estate planning, management and transfer when a party dies."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.immigration",
+      "definition": "A lawyer or law firm with expertise in immigration law."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.litigation",
+      "definition": "A lawyer or law firm with expertise in litigation. Not a category for lawyers who practice law across multiple fields."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.personalinjury",
+      "definition": "A lawyer or law firm with expertise in personal injury law"
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.realestate",
+      "definition": "A lawyer or law firm with expertise in real estate law."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.tax",
+      "definition": "A lawyer or law firm with expertise in tax law."
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.willtrustprobate"
+    },
+    {
+      "feature": "occupant",
+      "value": "lawyer.workerscomp",
+      "definition": "A law office or lawyer (barrister/attorney/solicitor) who advises and represents others in legal matters pertaining to workers compensation (e.g. on-the-job accidents and occupational diseases)."
+    },
+    {
+      "feature": "occupant",
+      "value": "leathergoods",
+      "definition": "A business specializing in items made from leather"
+    },
+    {
+      "feature": "occupant",
+      "value": "lebanese",
+      "definition": "An establishment specializing in Lebanese cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "legalservices",
+      "definition": "A business or organization who provide services related to legal matters, but are not lawyers themselves."
+    },
+    {
+      "feature": "occupant",
+      "value": "library",
+      "definition": "A building or room where media is collected for people to read, borrow, and reference. Traditionally this is mostly books, but may also include other media too."
+    },
+    {
+      "feature": "occupant",
+      "value": "lifecoach",
+      "definition": "An individual who provides motivational guidance to improve client's lives"
+    },
+    {
+      "feature": "occupant",
+      "value": "lighting",
+      "definition": "A business with expertise in lighting systems, including their design, installation and repair."
+    },
+    {
+      "feature": "occupant",
+      "value": "ligurian",
+      "definition": "A restaurant specializing in the cuisine of Liguria, a coastal region of northwestern Italy. Ligurian cuisine is characterized by a strong use of herbs, lack of tomatoes and red or black peppers, and preparations of seafood and stuffed vegetables."
+    },
+    {
+      "feature": "occupant",
+      "value": "limo",
+      "definition": "A company that provides transportation services by limousines."
+    },
+    {
+      "feature": "occupant",
+      "value": "linens",
+      "definition": "A business that sells fabric goods such as bedding, tablecloths and towels."
+    },
+    {
+      "feature": "occupant",
+      "value": "lingerie",
+      "definition": "A business specializing in lingerie and related accessories"
+    },
+    {
+      "feature": "occupant",
+      "value": "livestocksales",
+      "definition": "An open space where people regularly gather for the purchase and sale of provisions, livestock, and/or other goods."
+    },
+    {
+      "feature": "occupant",
+      "value": "localservices"
+    },
+    {
+      "feature": "occupant",
+      "value": "locksmith",
+      "definition": "Businesses that offer lock installation and repair services for both properties and autos."
+    },
+    {
+      "feature": "occupant",
+      "value": "lotterystand",
+      "definition": "Primarily in Japan, lotteries are sold at designated lottery stands that only sell lotteries. Can be found in other Asian countries, too."
+    },
+    {
+      "feature": "occupant",
+      "value": "loungebar",
+      "definition": "A relaxed social space usually filled with lounges. Typically fancier than your average bar and more relaxed than a nightclub."
+    },
+    {
+      "feature": "occupant",
+      "value": "luggage",
+      "definition": "A business that specializes in the sale of travel items like suitcases."
+    },
+    {
+      "feature": "occupant",
+      "value": "luggagestorage",
+      "definition": "A staffed location where one can temporarily store one's luggage so as to not have to carry it. These are often found inside or near airports."
+    },
+    {
+      "feature": "occupant",
+      "value": "macaron",
+      "definition": "Food shops specializing in macarons, a pastry made with egg whites and almond powder; not to be confused with macaroons, which are made with coconuts."
+    },
+    {
+      "feature": "occupant",
+      "value": "magicians",
+      "definition": "Groups or individuals that specialize in performing magic tricks."
+    },
+    {
+      "feature": "occupant",
+      "value": "mailboxcenter",
+      "definition": "Businesses and locations that have PO boxes available to customers and may also include other types of commercial mail receivers."
+    },
+    {
+      "feature": "occupant",
+      "value": "makeupartist",
+      "definition": "Businesses or individuals who specialize in the application of makeup, such as lipstick, blush, and eye shadow."
+    },
+    {
+      "feature": "occupant",
+      "value": "malaysian",
+      "definition": "An establishment specializing in Malaysian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "mamak",
+      "definition": "Typically a type of stall or food vendor found in Malaysia serving Mamak food. Malaysian Mamak are Malaysians of Tamil Muslim origin and thus their ingredients and techniques are a fusion of these two regions and generally don't include pork. May also be used for restaurants inspired by Mamak culinary traditions."
+    },
+    {
+      "feature": "occupant",
+      "value": "manicurists"
+    },
+    {
+      "feature": "occupant",
+      "value": "marketing",
+      "definition": "A business or service designed to promote products or other businesses. This includes market research and advertising."
+    },
+    {
+      "feature": "occupant",
+      "value": "martialarts",
+      "definition": "Individuals or organizations offering instruction or faciitlies for the practice of martial arts (e.g. karate, kung fu, ju-jitzu, taekwondo, judo)."
+    },
+    {
+      "feature": "occupant",
+      "value": "massageschool",
+      "definition": "Schools specializing in the instruction of medical and therapeutic body massage techniques."
+    },
+    {
+      "feature": "occupant",
+      "value": "massagetherapist",
+      "definition": "Businesses or individuals who specialize in the rubbing and kneeding of muscles and joints of the body with the hands, especially to relieve tension and for the purpose of relaxation."
+    },
+    {
+      "feature": "occupant",
+      "value": "massagetherapy",
+      "definition": "Businesses providing massage for strictly medical purposes (as opposed to general relaxation). Most treatments are for carpal tunnel, fibromyalgia, spinal injuries and muscle strain."
+    },
+    {
+      "feature": "occupant",
+      "value": "maternitywear",
+      "definition": "A business selling clothing designed for pregnant women"
+    },
+    {
+      "feature": "occupant",
+      "value": "mattresses",
+      "definition": "A business that specializes in the sale of beds, bed frames and mattresses."
+    },
+    {
+      "feature": "occupant",
+      "value": "mauritian",
+      "definition": "A restaurant that specializes in Mauritius cuisine (regional food from the Republic of Mauritius), which has strong Indian, European, French, Creole, African, and Chinese influences and is typically spicy. Common dishes/foods include curry (cari), mine-frit, niouk nien, roti, gateau piment, fruit salad, millionarie's salad, rougaille, vindaye, dholl puris, and achard."
+    },
+    {
+      "feature": "occupant",
+      "value": "meatballs",
+      "definition": "A restaurant specializing in the preparation of meatballs."
+    },
+    {
+      "feature": "occupant",
+      "value": "medicalcenter",
+      "definition": "Large facilities, slightly different than hospitals, though serving many of the same purposes, where medical care is administered, typically for continuing treatment and specialized care. Do not use for small medical practices or urgent care facilities."
+    },
+    {
+      "feature": "occupant",
+      "value": "medicalspa",
+      "definition": "Businesses offering multiple high-quality personal care treatments, such as massage, facials, nail care and waxing, in a relaxing atmosphere. Can be used with MedSpas in special cases."
+    },
+    {
+      "feature": "occupant",
+      "value": "medicalsupplies",
+      "definition": "A business that sells medical supplies, does not offer medication, treatment or diagnosis."
+    },
+    {
+      "feature": "occupant",
+      "value": "mediterranean",
+      "definition": "An establishment specializing in cuisine from the Mediterranean"
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican",
+      "definition": "An establishment specializing in Mexican cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican.easternmexican",
+      "definition": "A restaurant specializing in the cuisine of the Gulf Coast of Eastern Mexico and primarily originating from the states of Veracruz and Tabasco."
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican.jaliscan",
+      "definition": "A restaurant specializing in cuisine from the Mexican state of Jalisco, a state whose gastronomy is known for its pozole, sopitos, menudo, guacamole, cuachala, birria, pollo a la valenciana and tortas ahogadas"
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican.modern",
+      "definition": "**Does not mean modern Mexican cuisine; refers to the regional cuisine from the US state of New Mexico** A food establishment specializing in New Mexican cuisine, a fusion of Spanish and Mediterranean, Mexican, Pueblo Native American, and Cowboy Chuckwagon influences with red and green chiles as defining ingredients. Popular dishes include carne adovada, posole, green chile stew, calabacitas, stuffed sopapilla, and biscochitos. (Note: New Mexican food is not the same as Mexican and Tex-Mex foods preferred in Texas and Arizona. New Mexico is the only state with an official question‚\"red or green?\"‚ referring to the choice of red or green chile.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican.northernmexican",
+      "definition": "A restaurant specializing in the gastronomy of Northern Mexico, including the serving of grilled meats, different cheeses, and wheat tortillas."
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican.oaxacan",
+      "definition": "A restaurant specializing in cuisine from the Mexican state of Oaxaca, a state whose gastronomy is known for its \"seven moles,\" chapulines, Oaxaca tamales in banana leaves, tasajo and mescal."
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican.pueblan",
+      "definition": "A restaurant specializing in cuisine from the Mexican state of Puebla, a state whose gastronomy is best known for cemitas, mole poblano, chiles en nogada and chalupas."
+    },
+    {
+      "feature": "occupant",
+      "value": "mexican.yucatan",
+      "definition": "A restaurant specializing in cuisine from the Yucatán peninsula in southeastern Mexico."
+    },
+    {
+      "feature": "occupant",
+      "value": "middleeastern",
+      "definition": "An establishment specializing in cuisine from the Middle East"
+    },
+    {
+      "feature": "occupant",
+      "value": "militarybase",
+      "definition": "A place used as a center of operations by the armed forces or other military forces;"
+    },
+    {
+      "feature": "occupant",
+      "value": "milkbar",
+      "definition": "A suburban local general store or café, common in Australia, where people pick up milk and newspapers, and fast-food like fish and chips and hamburgers, and where people can purchase milkshakes or lollies."
+    },
+    {
+      "feature": "occupant",
+      "value": "milkshakes",
+      "definition": "A counter or place where a frothy drink made of cold milk, flavoring, and usually ice cream, shaken together or blended in a mixer are sold to customers."
+    },
+    {
+      "feature": "occupant",
+      "value": "minigolf",
+      "definition": "Courses designated for the sport of miniature golf, novelty form of golf focusing on putting and obstacles."
+    },
+    {
+      "feature": "occupant",
+      "value": "mobilephonerepair",
+      "definition": "A business that specializes in mobile phone repair and related services."
+    },
+    {
+      "feature": "occupant",
+      "value": "mobilephones",
+      "definition": "A business that primarily sells mobile phones. May also offer servicing and sell mobile phone accessories as well."
+    },
+    {
+      "feature": "occupant",
+      "value": "moneytransferservices",
+      "definition": "Business or entity that facilitates the transfer of funds between individuals or businesses."
+    },
+    {
+      "feature": "occupant",
+      "value": "mongolian",
+      "definition": "An establishment specializing in Mongolian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "moroccan",
+      "definition": "An establishment specializing in Moroccan cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "mortgagebroker",
+      "definition": "A business that serves as an intermediary between financial borrowers and lenders. The work of specific brokers varies but includes task such as marketing of financial products and services, assessment of prospective borrowers, gathering documents and completing application forms, offering advice to clients and communicating legal disclosures."
+    },
+    {
+      "feature": "occupant",
+      "value": "motorcyclingclothing",
+      "definition": "A business that sells all things associated with motorcycles. Items like helmets, clothing, equipment, etc. Not to be confused with motorcycle dealers who sell motorcycles"
+    },
+    {
+      "feature": "occupant",
+      "value": "movierental.kiosk",
+      "definition": "A movie rentalservices kiosk/box."
+    },
+    {
+      "feature": "occupant",
+      "value": "mughlai",
+      "definition": "A restaurant where the menu displays delicacies like biryani, haleem, kebabs and koftas."
+    },
+    {
+      "feature": "occupant",
+      "value": "museum.art",
+      "definition": "A museum specifically for art; an institution that exhibits a collection of artworks such as paintings, photographs, and sculptures. Unlike art galleries, art museums usually have permanent collections or endowments, charge entrance admission, adhere to a mission statement set forth by its founders, and do not try to sell the artworks on a regular basis. Generally speaking, an art museum is a non-profit institution and may be private or public."
+    },
+    {
+      "feature": "occupant",
+      "value": "museum.children",
+      "definition": "A museum specifically for children; an institution that provides exhibits and programs to stimulate informal learning experiences for children. In contrast with traditional museums that typically have a hands-off policy regarding exhibits, children's museums feature interactive exhibits that are designed to be manipulated by children. Most children's museums are nonprofit organizations."
+    },
+    {
+      "feature": "occupant",
+      "value": "museum.history",
+      "definition": "An institution that cares for (conserves) a collection of artifacts and other objects of historical importance."
+    },
+    {
+      "feature": "occupant",
+      "value": "musicalinstruments",
+      "definition": "A business specializing in the sale of musical instruments and may also offer musical lessons. note that there are also special categories for specialized stores like guitar stores or piano stores."
+    },
+    {
+      "feature": "occupant",
+      "value": "musicalinstrumentservices",
+      "definition": "Businesses or individuals that do not sell but provide specialized services for instruments such as tuning, transport and restoration. Should not be applied to services related to pianos as there is also a piano services category."
+    },
+    {
+      "feature": "occupant",
+      "value": "musicvenue",
+      "definition": "Businesses or facilities which primarily offer live music performances and concerts. Includes bars that offer live music performances the majority of operational nights."
+    },
+    {
+      "feature": "occupant",
+      "value": "musicvideo",
+      "definition": "A store specializing in the sale of music and video media (e.g. movies and tv shows)"
+    },
+    {
+      "feature": "occupant",
+      "value": "naga",
+      "definition": "Restaurants serving Naga fare are heavily reliant on non-vegetarian food items, Naga food items are either fried, boiled, smoked or fermented; bamboo shoots are a common element in almost all Naga dishes. Popular dishes at Naga restaurants include smoked pork stew, bamboo steamed fish which are served with a wide variety of spicy accompaniments such as crab chili sauce and ghost chili sauce."
+    },
+    {
+      "feature": "occupant",
+      "value": "nasilemak",
+      "definition": "A restaurant specializing in a Malay fragrant rice dish cooked in coconut milk and pandan leaf."
+    },
+    {
+      "feature": "occupant",
+      "value": "naturopathy",
+      "definition": "Doctors specializing in natural health, typically Eastern medicine. Do not use for practitioners without an MD license for practicing holistic treatments."
+    },
+    {
+      "feature": "occupant",
+      "value": "nepalese",
+      "definition": "Cuisine from the country of Nepal."
+    },
+    {
+      "feature": "occupant",
+      "value": "newspapersandmagazines",
+      "definition": "A business specializing in the sale of newspapers and magazines"
+    },
+    {
+      "feature": "occupant",
+      "value": "newzealand",
+      "definition": "A restaurant specializing in cuisine from New Zealand."
+    },
+    {
+      "feature": "occupant",
+      "value": "nicaraguan",
+      "definition": "A restaurant specializing in Nicaraguan cuisine. Well-known Nicaraguan dishes include nacatamal, vigor—n, indio viejo, quesillo, and sopa de mondongo. Due to its geography, Nicaraguan cuisine can also incorporate Caribbean flavors."
+    },
+    {
+      "feature": "occupant",
+      "value": "nightfood",
+      "definition": "A restaurant or eatery known for for operating at late hours when most other establishments have closed or offer limited food selections."
+    },
+    {
+      "feature": "occupant",
+      "value": "nonprofit",
+      "definition": "An organization whose purposes is other than making a profit and generally dedicated to furthering a particular social cause or advocating for a particular point of view."
+    },
+    {
+      "feature": "occupant",
+      "value": "noodles",
+      "definition": "A food establishment specializing in serving noodles, a staple food in many cultures made from unleavened dough which is stretched, extruded, or rolled flat and cut into one of a variety of shapes (e.g. waves, helices, tubes, strings, or shells). Noodles can be cooked/served in variety of ways, such as pan-fried, deep-fried, served with an accompanying sauce, or in a soup."
+    },
+    {
+      "feature": "occupant",
+      "value": "northamerican.traditional",
+      "definition": "An establishment specializing in traditional American (United States) cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "norwegian",
+      "definition": "A restaurant specializing in Norwegian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "notarypublic",
+      "definition": "A lawyer or individual with legal training who is licensed to perform acts in legal affairs, such as witnessing signatures on documents."
+    },
+    {
+      "feature": "occupant",
+      "value": "nurseries.gardening"
+    },
+    {
+      "feature": "occupant",
+      "value": "nyonya",
+      "definition": "A restaurant specializing in Peranakan or Nonya cuisine. Nonya cuisine comes from early Chinese migrants who settled in Penang, Malacca, Singapore and Indonesia and generally consists of Chinese ingredients with various distinct spices and cooking techniques used by the Malay/Indonesian community."
+    },
+    {
+      "feature": "occupant",
+      "value": "obgyn",
+      "definition": "Doctors or practices specializing in female reproductive health."
+    },
+    {
+      "feature": "occupant",
+      "value": "observatory",
+      "definition": "Facilities dedicated to the obesrvation of natural or astronmical phenomena."
+    },
+    {
+      "feature": "occupant",
+      "value": "occupationaltherapy",
+      "definition": "Health care professionals specializing in treatments used to develop, recover, or maintain the daily life and work skills of patients with physical, mental, or developmental conditions."
+    },
+    {
+      "feature": "occupant",
+      "value": "officebuilding",
+      "definition": "A single structure used to conduct business."
+    },
+    {
+      "feature": "occupant",
+      "value": "officeequipmentandsupplies",
+      "definition": "A shop that specializes in items intended for everyday use by businesses. Pens, paper, printing, office equipment, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "okinawan",
+      "definition": "A restaurant specializing in Okinawan cuisine. Also known as Ryukyuan cuisine, Okinawan cuisine differs from mainland Japanese cuisine in that it includes a stronger influence from Chinese and Southeast Asian cuisines."
+    },
+    {
+      "feature": "occupant",
+      "value": "oliveoil",
+      "definition": "A store that primarily sells olive oil. OK to use for olive oil farms."
+    },
+    {
+      "feature": "occupant",
+      "value": "opensandwiches",
+      "definition": "A food establishment that specializes in open face sandwiches, generally slices of bread with one or more food items on top."
+    },
+    {
+      "feature": "occupant",
+      "value": "opera.ballet"
+    },
+    {
+      "feature": "occupant",
+      "value": "opthamalogy",
+      "definition": "Medical doctors specializing in surgery and medical treatments of the eye, who have been trained in medical school and can perform eye surgery and provide advanced eye treatments (unlike optometrists)."
+    },
+    {
+      "feature": "occupant",
+      "value": "opticians",
+      "definition": "A business specializing in the sale of eyewear (glasses and contacts) and may also offer some eye assessment onsite as well."
+    },
+    {
+      "feature": "occupant",
+      "value": "optometry",
+      "definition": "Doctors specializing in non-surgical care of the eye, typically with eyesight assessment, eyeglasses, and contact lenses."
+    },
+    {
+      "feature": "occupant",
+      "value": "oralsurgery",
+      "definition": "Should be used exclusively for those dental professionals offering more complex surgical procedures, including dental implants and extraction of wisdom teeth."
+    },
+    {
+      "feature": "occupant",
+      "value": "organicfood",
+      "definition": "Stores that specialize in the sale of organic food. They are typically smaller markets that exclusively sell local and organic products."
+    },
+    {
+      "feature": "occupant",
+      "value": "oriental",
+      "definition": "A food establishment serving dishes that utilize a variety of the cooking practices and traditions found throughout Asia."
+    },
+    {
+      "feature": "occupant",
+      "value": "orthodontics",
+      "definition": "A dental professional primarily focused on the diagnosis, prevention and correction of malpositioned teeth and the jaws, usually with the utilization of braces, retainers and related devices."
+    },
+    {
+      "feature": "occupant",
+      "value": "orthopedics",
+      "definition": "Doctors that specialize in the care of bones and joints."
+    },
+    {
+      "feature": "occupant",
+      "value": "orthotics",
+      "definition": "Businesses that provide devices to externally modify the functional and structural characteristics of muscles and bones."
+    },
+    {
+      "feature": "occupant",
+      "value": "osteopathy",
+      "definition": "Fully licensed physicians who practice in every medical specialty​."
+    },
+    {
+      "feature": "occupant",
+      "value": "ottoman",
+      "definition": "Ottoman cuisine is the cuisine of Ottoman Turkey and is a fusion and refinement of Central Asian, Middle Eastern and Balkan cuisines. ÒPalace cuisineÓ is also a form of Ottoman cuisine. Some of the most prominent dishes include: HŸnkar be_endi (roasted eggplant puree), mahmudiye (eggs with onion), _eyhŸ-l muh_i (stuffed eggplant), el basan tava (lamb in bechamel sauce), chard with rice, stuffed okra, stuffed melon, grilled lamb meat, tutmaç soup (yogurt soup with lamb meatballs), dane-i saru pilavõ (pilaf made with saffron), dane-i ye_il pilavõ (pilaf made with spinach, mint, parsley, dill, celery stalks), kubuni pilavõ (rice with almond and raisins), †zbek pilav (rice with lamb meat, onion, tomato, carrot), oven-cooked fish, grilled turbot, olive oil stuffed grape leaves, olive oil stuffed green peppers, tarhana soup (made of tomatoes and pimentos), ezogelin soup (a spicy red lentil soup), boza (a malt drink, made from fermented wheat), a_ure (a wheat pudding), zerde (saffron-flavored rice pudding), and gŸllaç (a dessert made with milk, pomegranate and a special kind of pasta)"
+    },
+    {
+      "feature": "occupant",
+      "value": "outdoorfurniture"
+    },
+    {
+      "feature": "occupant",
+      "value": "outdoorgear",
+      "definition": "A business that specializes in the sale of clothing, footwear and equipment designed to be used in the great outdoors and for camping."
+    },
+    {
+      "feature": "occupant",
+      "value": "outletmall",
+      "definition": "An outlet mall (or outlet center) is a type of shopping mall in which manufacturers sell their products directly to the public through their own stores. Other stores in outlet malls are operated by retailers selling returned goods and discontinued products, often at heavily reduced prices."
+    },
+    {
+      "feature": "occupant",
+      "value": "outletstore",
+      "definition": "A business offering cheaper than regular price goods. Typically these are factory seconds or clearance items."
+    },
+    {
+      "feature": "occupant",
+      "value": "oxygenbar",
+      "definition": "A bar where their primary business is serving oxygen to the public rather than alcohol."
+    },
+    {
+      "feature": "occupant",
+      "value": "pachinko",
+      "definition": "A business specializing in a type of mechanical game originating in Japan, used as both a form of recreational arcade game and as a gambling device."
+    },
+    {
+      "feature": "occupant",
+      "value": "packagelocker",
+      "definition": "Commercial self service lockers or booths for either receiving or dropping off parcels. Examples include Amazon Lockers and DHL Packstations."
+    },
+    {
+      "feature": "occupant",
+      "value": "packing",
+      "definition": "A business or individual specializing in packing residential or commercial belongings in preparation for a client's move. They typically do not move the items for the client."
+    },
+    {
+      "feature": "occupant",
+      "value": "packingsupplies",
+      "definition": "A business that primarily sells packing supplies (e.g. boxes, bubble wrap, packing tape, wine shippers, etc.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "paella",
+      "definition": "A food establishment that serves primarily rise based dishes of Spanish origin including Paella."
+    },
+    {
+      "feature": "occupant",
+      "value": "painmanagement",
+      "definition": "A doctor/professional who specializes in pain management and prevention."
+    },
+    {
+      "feature": "occupant",
+      "value": "paintandsip",
+      "definition": "Businesses or individuals that offer painting classes where students drink alcohol while they paint."
+    },
+    {
+      "feature": "occupant",
+      "value": "painting",
+      "definition": "A business or individual that paints both the exterior and interior of buildings"
+    },
+    {
+      "feature": "occupant",
+      "value": "paintstores",
+      "definition": "A retail location for commercial paints and painting supplies. Not to be confused with a store for artistic painting supplies."
+    },
+    {
+      "feature": "occupant",
+      "value": "paintyourownpottery",
+      "definition": "A business where customers can purchase unpainted already-fired pottery and ceramic pieces (bisque) and paint them onsite. Typically, the business will have a selection of bisqueware to choose from and offer a workspace for customers to paint their selected pieces. After the customer is finished with painting, the business will then fire the bisqueware for completion and the customer can pick it up at a later time. Although most of these businesses will offer basic instruction on how to paint pottery pieces, they should not be categorized under Art Classes."
+    },
+    {
+      "feature": "occupant",
+      "value": "pakistani",
+      "definition": "An establishment specializing in Indian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "parentingschool",
+      "definition": "Organizations that provide classes that teach techniques for raising children."
+    },
+    {
+      "feature": "occupant",
+      "value": "parking",
+      "definition": "Locations that provide office space to park vehicles, usually for a fee."
+    },
+    {
+      "feature": "occupant",
+      "value": "parks",
+      "definition": "Public outdoor spaces for non-specific leisure activities such as picnics, hiking, and recreational sports."
+    },
+    {
+      "feature": "occupant",
+      "value": "parma",
+      "definition": "A food establishment that serves chicken parmigiana or parma as one of the main dishes. Restaurants specializing in cuisine from the province of Parma in Italy should be listed under the Italian restaurant category Emilian."
+    },
+    {
+      "feature": "occupant",
+      "value": "parsi",
+      "definition": "Heavily influenced by Iranian cuisine, Parsi restaurants are known for their non-vegetarian spread. Popular items include Dhansak, Berry Pulao, Patra ni Machi, Bun-Maska and chai."
+    },
+    {
+      "feature": "occupant",
+      "value": "partycharacters",
+      "definition": "Individuals or businesses offering actors for hire to dress and impersonate popular characters for special events, e.g. birthday parties."
+    },
+    {
+      "feature": "occupant",
+      "value": "partyequipment.rental",
+      "definition": "Businesses that rent party equipment for a fee, e.g. businesses that rent chairs."
+    },
+    {
+      "feature": "occupant",
+      "value": "partysupplies",
+      "definition": "Businesses that sell goods for celebrations, such as decorations, themed plates and silverware. Do not use for party equipment rentalservices."
+    },
+    {
+      "feature": "occupant",
+      "value": "passportvisaservices",
+      "definition": "A business or individual that specializes in passport and visa services such as applications, renewals, replacements, corrections, and so on."
+    },
+    {
+      "feature": "occupant",
+      "value": "pasta",
+      "definition": "Small shops where fresh pasta is made, e.g. ravioli, tortellini, as opposed to the dry boxed pasta found in supermarkets."
+    },
+    {
+      "feature": "occupant",
+      "value": "pathology",
+      "definition": "A doctor who specializes in the cause and development of diseases and facilitates diagnosis and treatment through examining tissues, checking the accuracy of and interpreting lab tests."
+    },
+    {
+      "feature": "occupant",
+      "value": "pawn",
+      "definition": "A store that accepts goods in exchange for a short term loan of cash. When the loan is not repaid back in time, the good maybe sold. As such these locations also sell items."
+    },
+    {
+      "feature": "occupant",
+      "value": "paydayloan",
+      "definition": "Businesses providing short-term loans or check cashing services for a fee."
+    },
+    {
+      "feature": "occupant",
+      "value": "pediatrics",
+      "definition": "Doctors specializing in the care of children."
+    },
+    {
+      "feature": "occupant",
+      "value": "performingarts",
+      "definition": "Art forms in which artists use their voices and/or the movements of their bodies, often in relation to other objects, to convey artistic expression. Examples include ballet, circus skills, clown, magic, dance, mime, opera, puppetry, speech, theatre, ventriloquism"
+    },
+    {
+      "feature": "occupant",
+      "value": "perfume",
+      "definition": "A business that sells products consisting of a mixture of fragrant essential oils or aroma compounds."
+    },
+    {
+      "feature": "occupant",
+      "value": "periodontics",
+      "definition": "A dental professional with expertise in the treatment of gum disease, oral inflammation, and the placement and maintenance of dental implants."
+    },
+    {
+      "feature": "occupant",
+      "value": "permanentmakeup",
+      "definition": "Businesses or individuals specializing in the technique of tattooing pigment on the face to resemble makeup. Examples include eyelining and other permanent pigmentation to enhance the skin of the face, lips, and eyelids."
+    },
+    {
+      "feature": "occupant",
+      "value": "persian",
+      "definition": "An establishment specializing in Iranian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "personalcare",
+      "definition": "A person or business offering services related to personal care (bathing, feedings, dressing, etc.) This is usually because the individuals themselves cannot perform these tasks on their own, either due to injury, sickness or age."
+    },
+    {
+      "feature": "occupant",
+      "value": "personalshopper",
+      "definition": "A company or person who will do shopping for you"
+    },
+    {
+      "feature": "occupant",
+      "value": "personaltrainer",
+      "definition": "Individuals offering one-on-one training through a gym or other sports facility. Also applies to outdoor and indoor bootcamps."
+    },
+    {
+      "feature": "occupant",
+      "value": "peruvian",
+      "definition": "An establishment specializing in Peruvian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "pets",
+      "definition": "Businesses that specialize in associated care and maintenance of pets"
+    },
+    {
+      "feature": "occupant",
+      "value": "pets.adoption",
+      "definition": "Businesses that advocates and facilitates the adoption of pets"
+    },
+    {
+      "feature": "occupant",
+      "value": "pets.boarding",
+      "definition": "An establishment offering temporary accommodations for pets."
+    },
+    {
+      "feature": "occupant",
+      "value": "pets.grooming",
+      "definition": "A business or service that washes and grooms pets"
+    },
+    {
+      "feature": "occupant",
+      "value": "pets.photography",
+      "definition": "A business or individual that specializes in photography for pets and animals."
+    },
+    {
+      "feature": "occupant",
+      "value": "pets.sitting",
+      "definition": "A service where someone can look after a pet while the owner is away. Boarding is a facility where the pets will stay. Pet Sitting is where the sitter comes to the pet's home to care for them."
+    },
+    {
+      "feature": "occupant",
+      "value": "pets.training",
+      "definition": "A business or service that offers either classes or services to help train pets"
+    },
+    {
+      "feature": "occupant",
+      "value": "pets.transportation",
+      "definition": "A business that specializes in providing transportation and travelling services for animals. Typical services include taxi services, pick-up from/drop-off at airports, obtaining necessary documents for travelling, shipping, moving, and so on."
+    },
+    {
+      "feature": "occupant",
+      "value": "petstore",
+      "definition": "A business that sells pet products, like food, pens, cages, collars, etc. May also sell pets too"
+    },
+    {
+      "feature": "occupant",
+      "value": "petstore.fish",
+      "definition": "Establishment that primarily sells fish as pets, often tropical fish. Not to be used for places that sell fish for food."
+    },
+    {
+      "feature": "occupant",
+      "value": "petstore.reptile"
+    },
+    {
+      "feature": "occupant",
+      "value": "pharmacy",
+      "definition": "The scope of pharmacy practice includes more traditional roles such as compounding and dispensing of medications, and it also includes more modern services related to health care. Category not to be used for drugstore. A drugstore, may be set up as a \"convenience store\", and may sell cosmetics, toiletry items, first-aid supplies and patent medications, such as nonprescription cold medicines."
+    },
+    {
+      "feature": "occupant",
+      "value": "pharmacystore",
+      "definition": "A store that sells non-pharmacy medicines, chemicals, and cosmetics. Category not to be used for pharmacies. A drugstore, may be set up as a \"convenience store\", and may sell cosmetics, toiletry items, first-aid supplies and patent medications, such as nonprescription cold medicines."
+    },
+    {
+      "feature": "occupant",
+      "value": "phonechargingstation",
+      "definition": "Station or kiosk in public areas for people to charge cell phones."
+    },
+    {
+      "feature": "occupant",
+      "value": "photobooth.rental",
+      "definition": "Businesses that rent photo booths for use at events."
+    },
+    {
+      "feature": "occupant",
+      "value": "photography",
+      "definition": "Businesses or individuals specializing in taking professional photos for events, personal use, or art."
+    },
+    {
+      "feature": "occupant",
+      "value": "photography.event",
+      "definition": "Businesses providing photography for events such as weddings and engagements."
+    },
+    {
+      "feature": "occupant",
+      "value": "photography.session",
+      "definition": "Businesses specializing in session photography, such as portrait sessions, engagement sessions, or headshots, typically at studios or a specific setting."
+    },
+    {
+      "feature": "occupant",
+      "value": "photographyequipment",
+      "definition": "A store that sells cameras as well as film for cameras and may process and print photographs as well"
+    },
+    {
+      "feature": "occupant",
+      "value": "photographystore"
+    },
+    {
+      "feature": "occupant",
+      "value": "physicaltherapy",
+      "definition": "A facility that provides professional help with the treatment of disease, injury, or deformity by physical methods such as massage, heat treatment, and exercise rather than by drugs or surgery."
+    },
+    {
+      "feature": "occupant",
+      "value": "physician",
+      "definition": "Medical doctors, also known as physicians. Also applies to group practices of doctors."
+    },
+    {
+      "feature": "occupant",
+      "value": "piadina",
+      "definition": "A restaurant specializing in a thin Italian flatbread, usually made with white flour, lard or olive oil, salt and water."
+    },
+    {
+      "feature": "occupant",
+      "value": "pianobar",
+      "definition": "A venue with a performance space that features someone playing a piano or keyboard"
+    },
+    {
+      "feature": "occupant",
+      "value": "pianostore",
+      "definition": "A store specialized in piano sales and rentalservices."
+    },
+    {
+      "feature": "occupant",
+      "value": "pictureframing",
+      "definition": "A business specializing in the sale of frames. May also offer framing services as well"
+    },
+    {
+      "feature": "occupant",
+      "value": "pilates",
+      "definition": "Individuals or organizations offering instruction in the practice of pilates. Businesses in this category are typically highly specialized and contain \"Pilates\" in their name."
+    },
+    {
+      "feature": "occupant",
+      "value": "pita",
+      "definition": "A food establishment, generally serving Mediterranean, Balkan or Middle Eastern cuisine, whose main dishes utilize pita bread, often as wraps or sandwiches."
+    },
+    {
+      "feature": "occupant",
+      "value": "pizza",
+      "definition": "An establishment specializing in pizza"
+    },
+    {
+      "feature": "occupant",
+      "value": "placeofworship",
+      "definition": "A specially designed structure or consecrated space where individuals or a group of people such as a congregation come to perform acts of devotion, veneration, or religious study. Can include Abbey."
+    },
+    {
+      "feature": "occupant",
+      "value": "placeofworship.church",
+      "definition": "A place where people of the Christian faith can congregate and worship"
+    },
+    {
+      "feature": "occupant",
+      "value": "placeofworship.mosque",
+      "definition": "A place where people of the Muslim faith can congregate and worship"
+    },
+    {
+      "feature": "occupant",
+      "value": "placeofworship.synagogue",
+      "definition": "A place where people of the Jewish faith can congregate and worship"
+    },
+    {
+      "feature": "occupant",
+      "value": "placeofworship.unitarian",
+      "definition": "A Unitarian place of worship"
+    },
+    {
+      "feature": "occupant",
+      "value": "planetarium",
+      "definition": "Dome-shaped facilities dedicated to education about outer space."
+    },
+    {
+      "feature": "occupant",
+      "value": "plasticsurgery",
+      "definition": "A surgeon specialized in the restoration, reconstruction, or alteration of the human body. It can be divided into two categories: reconstructive surgery and cosmetic/aesthetic surgery."
+    },
+    {
+      "feature": "occupant",
+      "value": "playcenter",
+      "definition": "An establishment located within a building that offers activities normally associated with recreational pleasure and enjoyment."
+    },
+    {
+      "feature": "occupant",
+      "value": "playground",
+      "definition": "Outdoor venues for children's play, typically including equipment such as swings and seesaws. For businesses offering playgrounds for a fee, use active.kids_activities."
+    },
+    {
+      "feature": "occupant",
+      "value": "playsets",
+      "definition": "A store that primarily sells playsets and swingsets. This can also be used for businesses that construct custom playsets."
+    },
+    {
+      "feature": "occupant",
+      "value": "plaza",
+      "definition": "Urban space, such as a city square, open to the public."
+    },
+    {
+      "feature": "occupant",
+      "value": "podiatrists",
+      "definition": "Doctors that specialize in the care of the feet."
+    },
+    {
+      "feature": "occupant",
+      "value": "podiatry",
+      "definition": "A medical establishment specializing in evaluating and managing disorders of the lower leg, ankle and foot."
+    },
+    {
+      "feature": "occupant",
+      "value": "poke",
+      "definition": "A food establishment that specializes in poke, a raw fish salad usually made with soy sauce, onions, green onions, and sesame oil. Traditional poke is mostly raw tuna or octopus, but adapations may feature various shellfish or other kinds of fish. Other poke seasonings include chili peper, seaweed, fish eggs, furikake, and wasabi."
+    },
+    {
+      "feature": "occupant",
+      "value": "poledancingschool",
+      "definition": "Businesses that offer classes in pole dancing."
+    },
+    {
+      "feature": "occupant",
+      "value": "policestation",
+      "definition": "Base of operations for the police force"
+    },
+    {
+      "feature": "occupant",
+      "value": "policestation.koban",
+      "definition": "A kōban is typically a two-storied housing with a couple of rooms (although there is wide variation), with from one to more than ten police officers.[6] The officers in these buildings can keep watch, respond to emergencies, give directions, and otherwise interact with citizens on a more intimate basis than they could from a more distant station. Although often translated to English as \"police box\",the kōban bears little resemblance to the British police box."
+    },
+    {
+      "feature": "occupant",
+      "value": "polish",
+      "definition": "An establishment specializing in Polish cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "polish.pierogis",
+      "definition": "A food establishment specializing in pierogis, filled dumplings of East European origin."
+    },
+    {
+      "feature": "occupant",
+      "value": "poolcleaning",
+      "definition": "A business or individual that provides cleaning and general maintenance on pools or hot tubs."
+    },
+    {
+      "feature": "occupant",
+      "value": "poolhall",
+      "definition": "A venue with a number of pool tables for playing billiards, snooker, etc type games."
+    },
+    {
+      "feature": "occupant",
+      "value": "pooltablesupplies",
+      "definition": "A store that specializes in the sale of pool tables and associated supplies. Note that you cannot play pool or billiards in these locations"
+    },
+    {
+      "feature": "occupant",
+      "value": "popcorn",
+      "definition": "Stores specializing in gourmet and flavored popcorns."
+    },
+    {
+      "feature": "occupant",
+      "value": "popup",
+      "definition": "A temporary restaurant or food establishment, typically only available for a few nights, weeks, or months at various locations (from hotel courtyards and defunct restaurants to existing restaurants that are closed at night). Pop-up restaurants usually feature a specific chef/cusine and are an effective way for young professionals to gain exposure of their skills, providing a launching pad for chefs to attract investors and/or open full-time restaurants. Sometimes, businesses will even test the market out by opening a pop-up restaurant first. (Note: although often interchangeable with one another, Supper Clubs are usually less advertised, more exclusive (some are invite-only; \"speakeasies\" of restaurants) and feature different chefs/menus.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "popupshops",
+      "definition": "A permanent space for temporary retail businesses."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese",
+      "definition": "An establishment specializing in Portuguese cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.alentejo",
+      "definition": "A restaurant serving cuisine from Alentejo, a region of south-central and southern Portugal."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.algarve",
+      "definition": "A restaurant serving cuisine from Algarve, the southernmost region of continental Portugal"
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.azores",
+      "definition": "A restaurant serving cuisine from the Azorean islands of Portugal."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.beira",
+      "definition": "A restaurant serving cuisine from the traditional Beira province of Portugal."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.fadohouse",
+      "definition": "A restaurant specializing in Portuguese gastronomy and hosting performances of Fado, a traditional folk music made popular in the Lisbon area of Portugal."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.madeira",
+      "definition": "A restaurant specializing in the cuisine from Madeira, a Portuguese archipelago located in the north Atlantic Ocean."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.minho",
+      "definition": "A restaurant serving cuisine from the traditional Minho province of northwestern Portugal."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.ribatejo",
+      "definition": "A restaurant serving cuisine from the traditional Ribatejo province of central Portugal."
+    },
+    {
+      "feature": "occupant",
+      "value": "portuguese.trasosmontes",
+      "definition": "A restaurant serving cuisine from the traditional Trás-os-Montes e Alto Douro province of northeastern Portugal."
+    },
+    {
+      "feature": "occupant",
+      "value": "postoffice",
+      "definition": "A public service responsible for mail services. Non government run operations should go in the shipping centers category"
+    },
+    {
+      "feature": "occupant",
+      "value": "postoffice.authorizedagent",
+      "definition": "A licensed professional authorized to offer postal services."
+    },
+    {
+      "feature": "occupant",
+      "value": "potatoes",
+      "definition": "A food establishment specializing in baked or jacket potatoes and other potato based dishes."
+    },
+    {
+      "feature": "occupant",
+      "value": "poutineries",
+      "definition": "An establishment specialize in serving Poutine (hot chips, gravy and cheese curds)."
+    },
+    {
+      "feature": "occupant",
+      "value": "prenatal",
+      "definition": "A business or service that offers care and guidance to people through their pregnancy (prenatal) to caring for their new born (perinatal)."
+    },
+    {
+      "feature": "occupant",
+      "value": "preschool",
+      "definition": "Schools for children too young to attend elementary school. Should incorporate an element of learning, offering more than a typical daycare."
+    },
+    {
+      "feature": "occupant",
+      "value": "pretzels",
+      "definition": "Businesses that specialize in the sale of pretzels, a crisp biscuit baked in the form of a knot, or a stick, and flavored with salt."
+    },
+    {
+      "feature": "occupant",
+      "value": "preventivemedicine",
+      "definition": "A doctor/professional who specializes in preventing diseases and illnesses (rather than treating them). Although many physicians practice preventive medicine, this category should only be used for specialists who DO NOT offer treatment."
+    },
+    {
+      "feature": "occupant",
+      "value": "printmedia",
+      "definition": "A business or organization that creates media to be read. These include newspapers and magazine publishers."
+    },
+    {
+      "feature": "occupant",
+      "value": "privateinvestigation",
+      "definition": "A business or organization who can be hired to perform private detective work, independent of law enforcement"
+    },
+    {
+      "feature": "occupant",
+      "value": "privatejetcharter",
+      "definition": "A business that offers private transportation by jet."
+    },
+    {
+      "feature": "occupant",
+      "value": "privateschool",
+      "definition": "Independent, non-governmental schools, that are not administered by local, state or national governments."
+    },
+    {
+      "feature": "occupant",
+      "value": "privateshuttlebus",
+      "definition": "A private company offering bus transportation."
+    },
+    {
+      "feature": "occupant",
+      "value": "professionalservices"
+    },
+    {
+      "feature": "occupant",
+      "value": "professionalsportsteam",
+      "definition": "Sports teams on the national and professional level (e.g. football, baseball, basketball, hockey). Do not use for amateur sports leagues."
+    },
+    {
+      "feature": "occupant",
+      "value": "propertymanagement",
+      "definition": "A business that manages the facilities of rentalservices properties including general upkeep and repairs."
+    },
+    {
+      "feature": "occupant",
+      "value": "psychiatrists",
+      "definition": "Doctors specializing in the treatment of emotional and mental disorders. Do not use for psychologists (psychiatrists have MDs and can proscribe medication)."
+    },
+    {
+      "feature": "occupant",
+      "value": "psychiatry",
+      "definition": "A business or clinic offering services in psychiatric care and mental health counseling."
+    },
+    {
+      "feature": "occupant",
+      "value": "psychic",
+      "definition": "Individuals specializing in psychic advisory services, i.e. fortune-tellers. Do not use with medical professions."
+    },
+    {
+      "feature": "occupant",
+      "value": "psychology",
+      "definition": "A professional (usually with a PhD or Doctor of Psychology) offering the diagnoses and treatment of mental disorders. Psychologists (as opposed to psychiatrists) lack medical degrees and are unable to prescribe medications."
+    },
+    {
+      "feature": "occupant",
+      "value": "pub",
+      "definition": "A bar that offers a casual setting and comfortable seating. Offers meals and more of a family atmosphere than a regular bar."
+    },
+    {
+      "feature": "occupant",
+      "value": "publicart",
+      "definition": "Any art which is exhibited in a public space, usually outdoor and permanent/semi-permanent. Common locations include parks, city plazas, walls (murals), outside corporate buildings, and sidewalks. Unlike street art, public art is usually commissioned by an art gallery or other commisioning bodies and created by specifically picked artists."
+    },
+    {
+      "feature": "occupant",
+      "value": "publiclibrary",
+      "definition": "A library that is accessible by the general public and is generally funded from public sources, such as taxes. Their mandate is to serve the general public's information needs and provide basic services without charge."
+    },
+    {
+      "feature": "occupant",
+      "value": "publicservices.government"
+    },
+    {
+      "feature": "occupant",
+      "value": "publictransport",
+      "definition": "Transportation owned or directly commissioned by governments in the interest of and available to the general public such as local buses, subways or ferry services."
+    },
+    {
+      "feature": "occupant",
+      "value": "puertorican",
+      "definition": "An establishment specializing in Puerto Rican cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "pulmonology",
+      "definition": "Doctors that specialize in pulmonary/respiratory problems."
+    },
+    {
+      "feature": "occupant",
+      "value": "punjabi",
+      "definition": "Restaurant specializing in Punjabi cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "racetrack",
+      "definition": "Outdoor racing venues where spectators view and bet on races."
+    },
+    {
+      "feature": "occupant",
+      "value": "radiology",
+      "definition": "Medical doctors that specialize in medical imaging, e.g. MRIs, CT scans, or PETs."
+    },
+    {
+      "feature": "occupant",
+      "value": "radiostation",
+      "definition": "A business or organization that broadcast radio signals, typically called radio stations"
+    },
+    {
+      "feature": "occupant",
+      "value": "rawfood",
+      "definition": "An establishment specializing raw, uncooked fruits and vegetables, and grains, nuts and seeds. No cooking involved."
+    },
+    {
+      "feature": "occupant",
+      "value": "realestate.agents"
+    },
+    {
+      "feature": "occupant",
+      "value": "realestate.services"
+    },
+    {
+      "feature": "occupant",
+      "value": "realestateagents",
+      "definition": "Businesses or individuals that work with property owners to coordinate the marketing and sale of their properties and residences."
+    },
+    {
+      "feature": "occupant",
+      "value": "realestateagents.commercial",
+      "definition": "A company or organization that markets and manages the sale of commercial properties."
+    },
+    {
+      "feature": "occupant",
+      "value": "realestateservices",
+      "definition": "Businesses or individuals offering services around real estate transactions, including home staging and escrow. They do not participate in the direct transaction of properties but often partner with agents or clients for the provision of specific services."
+    },
+    {
+      "feature": "occupant",
+      "value": "recordingstudio",
+      "definition": "A space where one can professionally record music and/or rehearse"
+    },
+    {
+      "feature": "occupant",
+      "value": "recreation",
+      "definition": "Business or location related to recreational activities."
+    },
+    {
+      "feature": "occupant",
+      "value": "recreationcenter",
+      "definition": "Designated area/building housing multiple sporting activities. Usually found on a college/university campus (but not limited to)."
+    },
+    {
+      "feature": "occupant",
+      "value": "recyclingcenter",
+      "definition": "A business that accepts recycled items and processes them for reuse"
+    },
+    {
+      "feature": "occupant",
+      "value": "reflexology",
+      "definition": "A person or business offering treatment via a style of massage used to relieve tension and treat illness, based on the theory that there are reflex points on the feet, hands, and head linked to every part of the body."
+    },
+    {
+      "feature": "occupant",
+      "value": "religiousitems",
+      "definition": "A business that primarily sells religious items and gifts (items pertaining to a specific religion). Examples include religious books, music, jewelry and statues.tems"
+    },
+    {
+      "feature": "occupant",
+      "value": "rental.videoandgame",
+      "definition": "A business that rents out videos, DVDs, blue rays, video games, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "researchanddevelopment",
+      "definition": "A facility dedicated to the systematic investigation into and study of materials and sources in order to establish facts and reach new conclusions."
+    },
+    {
+      "feature": "occupant",
+      "value": "residentialapartments",
+      "definition": "A complex or building with multiple housing units that can be either rented, leased, or sold on a long-term basis."
+    },
+    {
+      "feature": "occupant",
+      "value": "restaurant",
+      "definition": "An establishment that serves food."
+    },
+    {
+      "feature": "occupant",
+      "value": "retirementhome",
+      "definition": "A specially designed facility catering to the care of the elderly and infirm"
+    },
+    {
+      "feature": "occupant",
+      "value": "reunionnese",
+      "definition": "A restaurant that specializes in R√É¬©unionnese cuisine (regional food from the island of Reunion of France), which has strong influences from Africa, Madagascar, India, China, and France. Reunion cuisine is known for its spices and its use of local fruits, vegetables, and seafood. Common dishes/foods include curry (cari), rougail, brèdes, samoussas, bouchons, and le Americain."
+    },
+    {
+      "feature": "occupant",
+      "value": "reupholstery",
+      "definition": "A business or individual specialized in replacing or repairing the aged and damaged padding and coverings of furniture including that of homes, cars, boats and occasionally mattresses."
+    },
+    {
+      "feature": "occupant",
+      "value": "riceshop",
+      "definition": "Food establishments specialized in the preparation of Pilaf and other rice dishes."
+    },
+    {
+      "feature": "occupant",
+      "value": "rideshare",
+      "definition": "Business or service that facilitates ride sharing or carpooling allowing multiple riders to share a car trip."
+    },
+    {
+      "feature": "occupant",
+      "value": "robatayaki",
+      "definition": "A food establishment specializing in robatayaki, a Japanese method of cooking, similar to barbecue, in which items of food on skewers are slow-grilled over hot charcoal."
+    },
+    {
+      "feature": "occupant",
+      "value": "rockclimbing",
+      "definition": "Businesses that support the activity of rock climbing or locations for rock climbing (indoor or outdoor)."
+    },
+    {
+      "feature": "occupant",
+      "value": "rodizio",
+      "definition": "All-you-can-eat style Brazilian restaurants."
+    },
+    {
+      "feature": "occupant",
+      "value": "romanian",
+      "definition": "A restaurant specializing in Romanian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "roofing",
+      "definition": "A business or individual that constructs and/or repairs roofs."
+    },
+    {
+      "feature": "occupant",
+      "value": "rotisseriechicken",
+      "definition": "A restaurant that specializes in the preparation of chicken cooked on a rotisserie"
+    },
+    {
+      "feature": "occupant",
+      "value": "rugs",
+      "definition": "A shop where one can buy rugs and carpet"
+    },
+    {
+      "feature": "occupant",
+      "value": "russian",
+      "definition": "An establishment specializing in Russian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "sakebar",
+      "definition": "An establishment that serves a Japanese fermented, mildly alcoholic beverage made from rice."
+    },
+    {
+      "feature": "occupant",
+      "value": "salad",
+      "definition": "An establishment that sells salads"
+    },
+    {
+      "feature": "occupant",
+      "value": "salvadoran",
+      "definition": "An establishment specializing in cuisine from El Salvador"
+    },
+    {
+      "feature": "occupant",
+      "value": "sandwiches",
+      "definition": "An establishment that sells sandwiches"
+    },
+    {
+      "feature": "occupant",
+      "value": "sauna",
+      "definition": "A facility where by one can experience a wet or dry heat for relaxation or therapeutic benfit"
+    },
+    {
+      "feature": "occupant",
+      "value": "scandinavian",
+      "definition": "An establishment specializing in Scandinavian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "scandinaviandesign",
+      "definition": "A store specializing in the sale of items, usually furniture or homeware, that are characterized by the themes of Scandinavian Design. a design movement that emphasizes simplicity, minimalism and functionality and emerged in the Nordic countries during the 1950s."
+    },
+    {
+      "feature": "occupant",
+      "value": "school",
+      "definition": "Represents an institution that is for the education of children, generally from K-12. Some countries refer to them as primary and secondary education."
+    },
+    {
+      "feature": "occupant",
+      "value": "scottish",
+      "definition": "An establishment specializing in Scottish cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "screenprinting",
+      "definition": "A person or company that uses screen printing technique to create products like t-shirts and posters"
+    },
+    {
+      "feature": "occupant",
+      "value": "screenprinting.tshirt",
+      "definition": "A person or company that uses screen printing technique to create products like t-shirts and posters"
+    },
+    {
+      "feature": "occupant",
+      "value": "seafood",
+      "definition": "An establishment specializing in seafood"
+    },
+    {
+      "feature": "occupant",
+      "value": "seafoodmarket",
+      "definition": "Markets specializing in seafood."
+    },
+    {
+      "feature": "occupant",
+      "value": "securitysystems",
+      "definition": "A business or individual that specializes in the set-up and provision of home security systems."
+    },
+    {
+      "feature": "occupant",
+      "value": "selfstorage",
+      "definition": "A business offering space to store items. Typically the customer can access their space at any time and provides their own locks."
+    },
+    {
+      "feature": "occupant",
+      "value": "senegalese",
+      "definition": "An establishment specializing in Senegalese cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "seniorcenter",
+      "definition": "A facility where senior citizens can visit during the daytime for recreational and social activities. These locations may provide activities such as aerobics, field trips to local attractions, arts and crafts workshops, volunteering events, and so on. Senior centers do not involve residency and do not provide medical care."
+    },
+    {
+      "feature": "occupant",
+      "value": "serbianandcroatian",
+      "definition": "A restaurant specializing in a subset of Balkan cuisine originating from the entire region where the Serbo-Croatian language is spoken."
+    },
+    {
+      "feature": "occupant",
+      "value": "sewingalterations",
+      "definition": "A service alters, repairs and tailors clothing"
+    },
+    {
+      "feature": "occupant",
+      "value": "sharedofficespace",
+      "definition": "A space available for companies and individuals to rent that offers the environment and amenities of a professional office space."
+    },
+    {
+      "feature": "occupant",
+      "value": "shavedice",
+      "definition": "Businesses that specialize in serving shaved ice, a dessert made from ground ice and flavored with syrup. Also referred to as snow cones."
+    },
+    {
+      "feature": "occupant",
+      "value": "shavedsnow",
+      "definition": "A food establishment that primarily serves shaved snow (or snow ice), an ice cream and shaved ice hybird dessert. Whereas traditional shaved ice is made by grinding plain ice then flavoring it with fruit syrups or condensed milk, shaved snow starts out closer to ice cream; flavorings are mixed into a base of milk and water then frozen into cylindrical blocks that look like giant candles. The blocks are mounted onto an ice shaver, which slices it off into sheets that look like snow and are thin enough that they melt in the mouth, much like cotton candy. Various toppings and sauces (e.g. mochi, red bean, chocolate syrup, fruits, condensed milk, etc.) are then added for serving."
+    },
+    {
+      "feature": "occupant",
+      "value": "shippingcenters",
+      "definition": "Private companies (not government run) that offer services for shipping items by mail"
+    },
+    {
+      "feature": "occupant",
+      "value": "shippingdropbox",
+      "definition": "Standalone box for dropping off or picking up letters and packages, typically operated by commercial companies."
+    },
+    {
+      "feature": "occupant",
+      "value": "shoerepair",
+      "definition": "A company specializing in shoe repair"
+    },
+    {
+      "feature": "occupant",
+      "value": "shoes",
+      "definition": "A business specializing in footwear."
+    },
+    {
+      "feature": "occupant",
+      "value": "shoeshine",
+      "definition": "A business or individual who specializes in polishing leather shoes or boots to extend the footwear's life and to restore, maintain, and improve their appearance."
+    },
+    {
+      "feature": "occupant",
+      "value": "shoestore"
+    },
+    {
+      "feature": "occupant",
+      "value": "shopping"
+    },
+    {
+      "feature": "occupant",
+      "value": "shoppingpassage",
+      "definition": "Shopping area along a street"
+    },
+    {
+      "feature": "occupant",
+      "value": "shutterinstallation",
+      "definition": "A business or individual specializing in window shutter installation and repair. Shutters differ from blinds and shades in being rigid (generally a wooden or composite material) rather than flexible."
+    },
+    {
+      "feature": "occupant",
+      "value": "signature",
+      "definition": "A restaurant highlighting the cuisine of a well-known and accomplished chef."
+    },
+    {
+      "feature": "occupant",
+      "value": "signmaking",
+      "definition": "A business or organization who can be hired to create signs"
+    },
+    {
+      "feature": "occupant",
+      "value": "silentdisco",
+      "definition": "An event where people dance to music broadcasted over wireless headphones, giving the effect of a room full of people dancing to nothing. Can be used for DJs who provide this service."
+    },
+    {
+      "feature": "occupant",
+      "value": "singaporean",
+      "definition": "An establishment specializing in Singaporean cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "skatepark",
+      "definition": "Designated locations for skateboarding or rollerblading, typically including rails, ramps, and halfpipes."
+    },
+    {
+      "feature": "occupant",
+      "value": "skatingequipment",
+      "definition": "A business that specializes in the sale of equipment for street sports such as skateboards, roller blades and associated clothing, footwear and protective gear. Not to be confused with bike shops as they have their own category"
+    },
+    {
+      "feature": "occupant",
+      "value": "skatingrink",
+      "definition": "Facilities designed for the recreational activities of ice skating or roller skating."
+    },
+    {
+      "feature": "occupant",
+      "value": "skiequipment",
+      "definition": "Sales and rentalservices locations for ski, snowboards and snow gear."
+    },
+    {
+      "feature": "occupant",
+      "value": "skincare",
+      "definition": "Businesses or individuals specializing in skin care treatments, such as skin peels, facials, or microderm abrasion treatment."
+    },
+    {
+      "feature": "occupant",
+      "value": "skydiving",
+      "definition": "Businesses offering skydiving or parachute jumping, or schools or individuals offering skydiving instruction."
+    },
+    {
+      "feature": "occupant",
+      "value": "sleepwear",
+      "definition": "A store specializing in the sale of clothing designed to be worn while sleeping. Should emphasize the comfort and utility of sleepwear while stores focusing more primarily on alluring nightwear and undergarments should be listed under separate categories such as lingerie."
+    },
+    {
+      "feature": "occupant",
+      "value": "slovakian",
+      "definition": "An establishment specializing in Slovakian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "soccer",
+      "definition": "Fields or venues dedicated to the sport of soccer (called \"football\" in the UK)."
+    },
+    {
+      "feature": "occupant",
+      "value": "socialclub",
+      "definition": "Locations where groups gather around a common interest, occupation or activity (e.g. hunting, fishing, science, politics, charitable work)."
+    },
+    {
+      "feature": "occupant",
+      "value": "socialservices",
+      "definition": "Public services provided by the government, private, and non-profit organizations. These public services aim to create more effective organizations, build stronger communities, and promote equality and opportunity"
+    },
+    {
+      "feature": "occupant",
+      "value": "softwaredevelopment",
+      "definition": "A business or service which helps design, create, develop software. This is covers everything from conception, design, programming and testing the software."
+    },
+    {
+      "feature": "occupant",
+      "value": "solarinstallation",
+      "definition": "A business or individual that provides and maintains solar electrical systems and panels."
+    },
+    {
+      "feature": "occupant",
+      "value": "sommeliers",
+      "definition": "A trained wine professional who specializes in all aspects of wine service. Sommeliers, or wine stewards, are experts in wine and food pairing and in serving wine to patrons."
+    },
+    {
+      "feature": "occupant",
+      "value": "soulfood",
+      "definition": "Similar to Southern food, this is a traditional African-American cuisine. Fried meats, cornbread, collared greens are typical dishes."
+    },
+    {
+      "feature": "occupant",
+      "value": "soup",
+      "definition": "An establishment specializing in soup"
+    },
+    {
+      "feature": "occupant",
+      "value": "southafrican",
+      "definition": "An establishment specializing in South African cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "southernunitedstates",
+      "definition": "An establishment specializing in cuisine from Southern USA. This includes fried chicken, cornbread, grits, pie, mashed potato, pit barbecue, fried greens."
+    },
+    {
+      "feature": "occupant",
+      "value": "southwestunitedstates",
+      "definition": "A food establishment specializing in the cuisine of the southwest United States. South Western cuisine is similar to Mexican cuisine but often involves larger cuts of meat, namely pork and beef, and less use of tripe, brain, and other parts not considered as desirable in the United States. Restaurants specializing in Tex-Mex, a type of South Western cuisine, should be listed under the Tex-Mex category instead."
+    },
+    {
+      "feature": "occupant",
+      "value": "souvenirs",
+      "definition": "Business selling local items and mementos tied to the store's location."
+    },
+    {
+      "feature": "occupant",
+      "value": "spanish",
+      "definition": "An establishment specializing in Spanish cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "spanish.andalusian",
+      "definition": "A restaurant specializing in the regional cuisine of Andalusia."
+    },
+    {
+      "feature": "occupant",
+      "value": "spanish.basque",
+      "definition": "An establishment specializing in Basque cuisine, a region of Northern Spain."
+    },
+    {
+      "feature": "occupant",
+      "value": "spanish.catalan",
+      "definition": "An establishment specializing in Catalonian cuisine (a region of Spain)."
+    },
+    {
+      "feature": "occupant",
+      "value": "spanish.galician",
+      "definition": "A restaurant specializing in Galician cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "specialtyfood"
+    },
+    {
+      "feature": "occupant",
+      "value": "specialtyschool",
+      "definition": "Schools that provide classes in specialized fields. Use only when the businesses does not fit other specialized child-education categories."
+    },
+    {
+      "feature": "occupant",
+      "value": "spinclass",
+      "definition": "A business that offers exercises involving using a special stationary exercise bicycle with a weighted flywheel in a classroom setting."
+    },
+    {
+      "feature": "occupant",
+      "value": "spiritualproducts",
+      "definition": "Business specializing in new age and spiritual teachings. Items often for sale are books, rocks and crystals, tarot cards."
+    },
+    {
+      "feature": "occupant",
+      "value": "sportinggoods"
+    },
+    {
+      "feature": "occupant",
+      "value": "sportsbar",
+      "definition": "A bar that hosts multiple TVs showing sports games."
+    },
+    {
+      "feature": "occupant",
+      "value": "sportsclub",
+      "definition": "Facilities or organizations hosting recreational sports."
+    },
+    {
+      "feature": "occupant",
+      "value": "sportsequipment.rental",
+      "definition": "A business offering a variety of sporting goods for rent"
+    },
+    {
+      "feature": "occupant",
+      "value": "sportsgoods",
+      "definition": "A business offering sports apparel, footwear and equipment."
+    },
+    {
+      "feature": "occupant",
+      "value": "sportsmedicine",
+      "definition": "Doctors specializing in the treatment of injuries typically sustained while playing sports."
+    },
+    {
+      "feature": "occupant",
+      "value": "sportsschool",
+      "definition": "A type of educational institution for children that focuses on the training of a particular sports, often in a boarding school environment. This type of educational institution exists in Russian speaking countries (Russia, Ukraine, Central Asian countries, etc), some East Asian countries (China, Singapore, Malaysia) also Germany and Cuba."
+    },
+    {
+      "feature": "occupant",
+      "value": "sportswear",
+      "definition": "A business that specializes in the sale of clothing and footwear designed to be used during sport or at the gym."
+    },
+    {
+      "feature": "occupant",
+      "value": "srilankan",
+      "definition": "An establishment specializing in Sri Lankan cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "stationery"
+    },
+    {
+      "feature": "occupant",
+      "value": "steak",
+      "definition": "An establishment specializing in steak"
+    },
+    {
+      "feature": "occupant",
+      "value": "stockings",
+      "definition": "A clothing store specializing in the sale of stockings and other close-fitting, elastic garments used to cover the leg."
+    },
+    {
+      "feature": "occupant",
+      "value": "streetvendor",
+      "definition": "Businesses that sell food on the street, but are not food trucks. They are characterized by minimal equipment and lack of a fixed location. Do not use for food stands."
+    },
+    {
+      "feature": "occupant",
+      "value": "structuralengineers",
+      "definition": "A business or professional with expertise in the design and construction of the structural components of buildings such as foundations, beams and supports."
+    },
+    {
+      "feature": "occupant",
+      "value": "subwaystation",
+      "definition": "A railway station for a rapid transit system, often known by names such as \"metro\", \"underground\" and \"subway\"."
+    },
+    {
+      "feature": "occupant",
+      "value": "supermarket",
+      "definition": "A larger grocery store, often part of a chain, that sells a large variety of produce and household goods. Eg. Safeway"
+    },
+    {
+      "feature": "occupant",
+      "value": "supperclub",
+      "definition": "A traditional dining establishment that also functions as a social club"
+    },
+    {
+      "feature": "occupant",
+      "value": "surfacerefinishing",
+      "definition": "A business or individual specializing in the restoration or repair of interior surfaces including bathtubs and stone countertops or floors."
+    },
+    {
+      "feature": "occupant",
+      "value": "surfing",
+      "definition": "Businesses offering instruction in surfing, or locations where surfing is the main activity. Do not use for businesses selling surfing gear."
+    },
+    {
+      "feature": "occupant",
+      "value": "surfingequipment",
+      "definition": "A business that specializes in the sale of equipment for surfing such as boards, wetsuits  and associated clothing. Not to be confused with swimwear as they have their own category"
+    },
+    {
+      "feature": "occupant",
+      "value": "surgeon",
+      "definition": "Physicians that specialize in performing surgery on patients."
+    },
+    {
+      "feature": "occupant",
+      "value": "sushi",
+      "definition": "An establishment specializing in sushi"
+    },
+    {
+      "feature": "occupant",
+      "value": "swedish",
+      "definition": "A restaurant specializing in Swedish cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "swedish.traditional",
+      "definition": "A food establishment specializing in the preparation of traditional Swedish cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "swimminginstruction",
+      "definition": "Businesses or individuals that teach swimming or swimming improvement techniques."
+    },
+    {
+      "feature": "occupant",
+      "value": "swimmingpool",
+      "definition": "Facilities where one can swim in a swimming pool."
+    },
+    {
+      "feature": "occupant",
+      "value": "swimwear",
+      "definition": "A business specializing in swimming attire."
+    },
+    {
+      "feature": "occupant",
+      "value": "swiss",
+      "definition": "A restaurant specializing in Swiss cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "syrian",
+      "definition": "A restaurant that specializes in Syrian cuisine, which is known for its small plates of appetizers known as \"mezze\". Common foods/dishes includes dishes like kibbeh bil sanieh, kebab halabi, waraq `inab, hummus, tabbouleh, fattoush, labneh, shawarma, mujaddara, shanklish, bastirma, sujuk, and baklava."
+    },
+    {
+      "feature": "occupant",
+      "value": "taberna",
+      "definition": "A non-formal establishment serving drinks and modest food dished from Spain."
+    },
+    {
+      "feature": "occupant",
+      "value": "tabletopgames"
+    },
+    {
+      "feature": "occupant",
+      "value": "tableware",
+      "definition": "A business that sells the dishes or dishware used for setting a table, serving food and dining. It includes cutlery, glassware, serving dishes and other useful items for practical as well as decorative purposes."
+    },
+    {
+      "feature": "occupant",
+      "value": "tacos",
+      "definition": "A restaurant that serves tacos, composed of a corn or wheat tortilla folded or rolled around a filling."
+    },
+    {
+      "feature": "occupant",
+      "value": "taiwanese",
+      "definition": "An establishment specializing in Taiwanese cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "taiyaki",
+      "definition": "A business specializing in Japanese fish-shaped cakes."
+    },
+    {
+      "feature": "occupant",
+      "value": "talentagencies",
+      "definition": "A business who represents entertainment industry professionals, securing work for them as well as negotiating contracts and ensuring safe working conditions."
+    },
+    {
+      "feature": "occupant",
+      "value": "tamales",
+      "definition": "A restaurant that serves tamales, a traditional Mesoamerican dish made of masa (a starchy dough, usually corn-based), which is steamed in a corn husk or banana leaf."
+    },
+    {
+      "feature": "occupant",
+      "value": "tanningbeds",
+      "definition": "Businesses that provide tanning beds or booths, often with florescent lighting."
+    },
+    {
+      "feature": "occupant",
+      "value": "tanningservices",
+      "definition": "Businesses specializing in tanning through the use of tanning beds and spray tanning; can have physical location or be mobile."
+    },
+    {
+      "feature": "occupant",
+      "value": "tapas",
+      "definition": "A bar offering small plates of food, typically of Spanish origin. Not a restaurant"
+    },
+    {
+      "feature": "occupant",
+      "value": "tapas.smallplate",
+      "definition": "A restaurant offering small plates of food, typically of Spanish origin."
+    },
+    {
+      "feature": "occupant",
+      "value": "tattoo",
+      "definition": "Businesses specializing in body tattoo."
+    },
+    {
+      "feature": "occupant",
+      "value": "tattoo.removal",
+      "definition": "Doctors specializing in tattoo removal."
+    },
+    {
+      "feature": "occupant",
+      "value": "taxi",
+      "definition": "A vehicle providing individualized transportation a location specified by the customer."
+    },
+    {
+      "feature": "occupant",
+      "value": "taxistand",
+      "definition": "An area where taxis park and wait for/pick up customers"
+    },
+    {
+      "feature": "occupant",
+      "value": "taxoffice",
+      "definition": "An establishment that offers tax preparation services."
+    },
+    {
+      "feature": "occupant",
+      "value": "taxservices",
+      "definition": "Businesses that provide tax-related services for clients, such as annual filing preparation."
+    },
+    {
+      "feature": "occupant",
+      "value": "tea",
+      "definition": "Establishments specializing in serving tea and other refreshments in a formal seating area."
+    },
+    {
+      "feature": "occupant",
+      "value": "teachersupplies",
+      "definition": "A store that primarily sell items for classroom use (generally catered to teachers), such as classroom furniture, educational toys and manipulatives, themed decorations, stickers, science fair/project supplies, arts & crafts supplies, workbooks, chalkboards, posters, awards/certificates/ribbons, etc. (Note: this shouldn't be used for stores that sell school supplies intended for students (e.g. binders, notebooks, paper, pens, etc.) - those should go under Office Equipment.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "teambuilding",
+      "definition": "A business or individual specializing in providing and/or organizing group activities intended to develop team bonding. Most activities will require patrons to work together as a team to achieve a common goal (e.g. solving a puzzle, getting through an obstacle course, guessing games, etc.) Please note this category should not be used as an attribute for an Active Life business that offers group packages or whose services are considered \"good for groups\"; this category should only be used for businesses whose core competency is providing/organizing team building activities or consultation."
+    },
+    {
+      "feature": "occupant",
+      "value": "teethwhitening",
+      "definition": "Businesses that specialize in the whitening of teeth for cosmetic purposes."
+    },
+    {
+      "feature": "occupant",
+      "value": "telecommunications",
+      "definition": "A business or organization that provides and services landline telephone systems."
+    },
+    {
+      "feature": "occupant",
+      "value": "televisionserviceproviders",
+      "definition": "A business or organization providing television services and content."
+    },
+    {
+      "feature": "occupant",
+      "value": "televisionstation",
+      "definition": "A business or organization that broadcast TV signals, typically called TV stations"
+    },
+    {
+      "feature": "occupant",
+      "value": "tennis.instruction",
+      "definition": "Tennis courts and businesses or individuals providing tennis lessons."
+    },
+    {
+      "feature": "occupant",
+      "value": "terminal",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as a terminal."
+    },
+    {
+      "feature": "occupant",
+      "value": "terminal.bus",
+      "definition": "A terminal where buses arrive and depart. Bus stations can be outdoor or indoor and can be big and small. Businesses located inside bus terminals should have separate listings (e.g. coffee shop, convenience store, cafe, etc.) This should not be used for individual bus stops."
+    },
+    {
+      "feature": "occupant",
+      "value": "testpreparationschool",
+      "definition": "Businesses or individuals specializing in preparing individuals for tests, such as the SATs, LSATs, and GMATs."
+    },
+    {
+      "feature": "occupant",
+      "value": "texmex",
+      "definition": "An establishment specializing in Tex-Mex cuisine, a cross between American and Mexican flavors and ingredients"
+    },
+    {
+      "feature": "occupant",
+      "value": "thai",
+      "definition": "An establishment specializing in Thai cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "theater.drivein",
+      "definition": "An outdoor space (usually a parking lot) with a large movie screen where people can view movies from the privacy and comfort of their automobiles. There will often be a projector booth and concession stand at the drive-in theater."
+    },
+    {
+      "feature": "occupant",
+      "value": "theater.movie",
+      "definition": "Venues where movies are shown, typically with light refreshments such as popcorn, candy, and soda available for purchase."
+    },
+    {
+      "feature": "occupant",
+      "value": "themedcafe",
+      "definition": "A cafe in which the concept of the cafe takes priority over everything else, influencing the architecture, food, music, and overall 'feel' of the cafe. The food and drinks usually take a backseat to the presentation of the theme, and these cafes attract customers solely on the premise of the theme itself. Some popular themed cafes include cat cafes, dog cafes, robot cafes, library cafes, maid cafes, and even cafes based on popular novels/fairytales/cartoon characters like Alice in Wonderland, Hello Kitty, Harry Potter, etc."
+    },
+    {
+      "feature": "occupant",
+      "value": "thriftstore",
+      "definition": "A retail location offering second hand goods, whose profit usually goes to charity."
+    },
+    {
+      "feature": "occupant",
+      "value": "tibetan",
+      "definition": "Eateries serving Tibetan fare are famous for dishes such as momos, thukpas and butter tea."
+    },
+    {
+      "feature": "occupant",
+      "value": "tickets",
+      "definition": "A business or location that sells, or makes available for pickup, tickets to local events and venues usually in the categories of arts, culture and entertainment."
+    },
+    {
+      "feature": "occupant",
+      "value": "tikibar",
+      "definition": "A tropical-themed drinking establishment that serves elaborate cocktails, especially rum-based mixed drinks such as the mai tai and zombie cocktail. Tiki bars are aesthetically defined by their tiki culture decor which is based upon a romanticized conception of tropical cultures, most commonly Polynesian. The interiors and exteriors of tiki bars often include \"tiki god\" masks and carvings, grasscloth, tapa cloth and tropical fabrics, torches, woven fish traps, and glass floats, bamboo, plants, lava stone, hula girl, palm tree motifs, tropical murals and other South Pacific-themed decorations. Indoor fountains, waterfalls or even lagoons are popular features. Some tiki bars also incorporate a stage for live entertainment such as exotica-style bands or Polynesian dance floor shows."
+    },
+    {
+      "feature": "occupant",
+      "value": "titleloan",
+      "definition": "A business that provides title loans, a type of loan where borrowers can use their vehicle title as collateral. (Not to be confused with Auto Loan Providers, who provide loans for purchasing a vehicle.)"
+    },
+    {
+      "feature": "occupant",
+      "value": "tobaccoshop",
+      "definition": "A business that specialises tobacco, cigarettes, and related products. Not to be confused with Vape shops or Head Shops."
+    },
+    {
+      "feature": "occupant",
+      "value": "tofu",
+      "definition": "A business specializing in a soft, bland, white cheeselike food, high in protein content, made from curdled soybean milk."
+    },
+    {
+      "feature": "occupant",
+      "value": "touristattraction",
+      "definition": "A place of interest to tourists typically for its inherent or exhibited natural or cultural value, historical significance, natural or built beauty, offering leisure, adventure and amusement."
+    },
+    {
+      "feature": "occupant",
+      "value": "tours",
+      "definition": "Businesses or organizations that offer guided tours."
+    },
+    {
+      "feature": "occupant",
+      "value": "tours.boat",
+      "definition": "A business or individual that provides short trips on a boat for tourist reasons, typically starting and ending in the same place, and normally of a duration less than a day. This contrasts with cruising in large ships for a number of days with accommodation in cabins. ttours"
+    },
+    {
+      "feature": "occupant",
+      "value": "tours.bus",
+      "definition": "A business or organization that provides tours where transportation to one or many areas of interest is provided by bus and integrated as part of the tour."
+    },
+    {
+      "feature": "occupant",
+      "value": "tours.scooter",
+      "definition": "A business or individual that offers tours by scooters, including self-balancing scooters like Segway and hoverboards, mopeds, and other light two-wheeled motor/electric vehicles."
+    },
+    {
+      "feature": "occupant",
+      "value": "tours.walking",
+      "definition": "Businesses or organizations that offer guided tours that include walking between places on interest. Walking tours organized for a particular theme, such as food or history, should fall under their respective theme categories rather than this walking tour category."
+    },
+    {
+      "feature": "occupant",
+      "value": "towncarservice",
+      "definition": "A luxury sedan driven by a chauffeur that is available for hire. Town car service usually cater to businesspeople, typically for traveling between airports and hotels, offices, and venues. Unlike a taxi, town car service requires advance booking and does not charge by meter. Unlike limos, town cars typically are not hired for events (e.g. proms, weddings, bachelor parties, etc) and the cars do not have a lengthened wheelbase. Unlike airport shuttles, town cars are rarely share and do not drive exclusively to/from airports."
+    },
+    {
+      "feature": "occupant",
+      "value": "toys",
+      "definition": "A business that sells toys and games"
+    },
+    {
+      "feature": "occupant",
+      "value": "toystore"
+    },
+    {
+      "feature": "occupant",
+      "value": "traditionalchinesemedicine",
+      "definition": "An alternative to western medicine, Traditional Chinese Medicine covers things like herbal medicine, massage and other alternate therapies."
+    },
+    {
+      "feature": "occupant",
+      "value": "trainserviceprovider",
+      "definition": "A company providing transportation services by trains."
+    },
+    {
+      "feature": "occupant",
+      "value": "trainstation",
+      "definition": "A location where one could expect to either board or alight from a train."
+    },
+    {
+      "feature": "occupant",
+      "value": "trampolining",
+      "definition": "Venues with wall-to-wall trampolines for fitness and parties, generally located indoors."
+    },
+    {
+      "feature": "occupant",
+      "value": "transitlounge",
+      "definition": "A lounge at a transit station (train/coach usually) accessible to passengers waiting for their scheduled departure. Wifi, refreshments, seating areas and other amenities are usually provided."
+    },
+    {
+      "feature": "occupant",
+      "value": "translationservices",
+      "definition": "A business or individual who offer translation services"
+    },
+    {
+      "feature": "occupant",
+      "value": "transportationservices",
+      "definition": "A business or organization a transportation service from one place to another. Should only be used if a more specific category is not available."
+    },
+    {
+      "feature": "occupant",
+      "value": "trattoria",
+      "definition": "An Italian-style eating establishment, less formal than a ristorante, but more formal than an osteria. There are generally no printed menus, the service is casual, wine is sold by the decanter rather than the bottle, prices are low, and the emphasis is on a steady clientele rather than on grande cuisine. The food is modest but plentiful (mostly following regional and local recipes) and in some instances is even served family-style (i.e. at common tables)."
+    },
+    {
+      "feature": "occupant",
+      "value": "travelagent",
+      "definition": "A business or individual that provides travel and tourism related services to the customer on behalf of suppliers such as airlines, car rentalservicess, cruise lines, hotels, railways, and package tours."
+    },
+    {
+      "feature": "occupant",
+      "value": "travelservices",
+      "definition": "A company that organizes and advises on travel arrangements and activities such as flights, hotels and tours."
+    },
+    {
+      "feature": "occupant",
+      "value": "trinidadian",
+      "definition": "An establishment specializing in cuisine from Trinidad."
+    },
+    {
+      "feature": "occupant",
+      "value": "trophyshops",
+      "definition": "An establishment offering the sale and personalization of trophies and awards"
+    },
+    {
+      "feature": "occupant",
+      "value": "truckrental",
+      "definition": "Businessess that specialize in truck rentalservices, such as U-Haul."
+    },
+    {
+      "feature": "occupant",
+      "value": "tuina"
+    },
+    {
+      "feature": "occupant",
+      "value": "turkish",
+      "definition": "An establishment specializing in Turkish cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "turkish.cheekufta",
+      "definition": "A food establishment specializing in the preparation of çiğ köfte, a raw meat dish in Turkish and Armenian cuisines"
+    },
+    {
+      "feature": "occupant",
+      "value": "turkish.gozleme",
+      "definition": "A food establishment specializing in the preparation of Turkish gozleme. Gozleme is a traditional savory Turkish flatbread and pastry dish, made of leaves of yufka dough that are lightly brushed with butter and eggs, filled with various toppings, sealed, and cooked over a griddle."
+    },
+    {
+      "feature": "occupant",
+      "value": "turkish.homemadefood",
+      "definition": "A food establishment that specializes in traditional Turkish cuisine that features recipes historically made at home by Turkish families."
+    },
+    {
+      "feature": "occupant",
+      "value": "turkish.lahmacun",
+      "definition": "A restaurant or food establishment that specializes in the preparation of lahmacun, also known as Turkish or Armenian pizza. It consists of a round, thin piece of dough topped with minced meat, vegetables and herbs that is baked."
+    },
+    {
+      "feature": "occupant",
+      "value": "turkish.ravioli",
+      "definition": "A restaurant or food establishment that specializes in the preparation of Turkish ravioli, also known as Manti or Turkish dumplings. Turkish ravioli usually consists of a spiced meat mixture in a dough wrapper that is either boiled or steamed."
+    },
+    {
+      "feature": "occupant",
+      "value": "tutoring",
+      "definition": "Brick-and-mortar businesses offering private, secondary, remedial, or specialized instruction, usually for common school subjects such as language, math, and science."
+    },
+    {
+      "feature": "occupant",
+      "value": "ukrainian",
+      "definition": "An establishment specializing in Ukrainian cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "uniforms",
+      "definition": "A business specializing in uniforms required for staff and students"
+    },
+    {
+      "feature": "occupant",
+      "value": "urgentcare",
+      "definition": "An organization offering walk in medical care of an urgent nature. Urgent is considered a level below Emergency rooms but more immediate than that of primary care like a family doctor."
+    },
+    {
+      "feature": "occupant",
+      "value": "usedbooks",
+      "definition": "A business or location that sells and/or exchanges used books. Not a library, which lends books on a membership basis."
+    },
+    {
+      "feature": "occupant",
+      "value": "utilities",
+      "definition": "A private or public organization that provides local utility services to the general public including electricity, water, natural gas and/or sewage."
+    },
+    {
+      "feature": "occupant",
+      "value": "uzbek",
+      "definition": "An establishment specializing in cuisine from Uzbekistan"
+    },
+    {
+      "feature": "occupant",
+      "value": "vacationhome",
+      "definition": "A property or residence that is available for vacation rentalservices and is not a hotel."
+    },
+    {
+      "feature": "occupant",
+      "value": "vacationhome.agent",
+      "definition": "A business or individual that markets and coordinates the rentalservices of vacation properties including condos and villas."
+    },
+    {
+      "feature": "occupant",
+      "value": "valetservices",
+      "definition": "Businesses that park cars for clients, such as at a restaurant, club, or at private events."
+    },
+    {
+      "feature": "occupant",
+      "value": "vapeshops",
+      "definition": "A business that offers vape products, e-cigarettes, and related products."
+    },
+    {
+      "feature": "occupant",
+      "value": "vascularmedicine",
+      "definition": "A doctor who specializes in the diagnosis and treatment of disorders of the vascular/blood system."
+    },
+    {
+      "feature": "occupant",
+      "value": "vegan",
+      "definition": "An establishment specializing in food with no animal products in it. No meat, no egg, no dairy."
+    },
+    {
+      "feature": "occupant",
+      "value": "vegetarian",
+      "definition": "An establishment specializing in vegetarian food. No meat served."
+    },
+    {
+      "feature": "occupant",
+      "value": "vendingmachine",
+      "definition": "Automated machine that provides items using a payment system. Please use shopping.vendingmachine.refreshments for food related machines."
+    },
+    {
+      "feature": "occupant",
+      "value": "vendingmachine.beverage",
+      "definition": "Automated machine that provides items like snacks or beverages using a payment system."
+    },
+    {
+      "feature": "occupant",
+      "value": "venezuelan",
+      "definition": "An establishment specializing in Venezuelan cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "venison",
+      "definition": "A restaurant that specializes in the preparation of venison, the meat of various species of deer."
+    },
+    {
+      "feature": "occupant",
+      "value": "veteransorganization",
+      "definition": "An organization that advocates for and assist veterans in everyday life, such as ensuring they receive medical care and benefits, providing social support and counseling, helping them find jobs, organizing social events and volunteering opportunities, and getting them involved in the larger community. It is not uncommon for these organizations to have an office/facility where veterans can go to for assistance or socializing."
+    },
+    {
+      "feature": "occupant",
+      "value": "veterinarian",
+      "definition": "Medical specialists for animals."
+    },
+    {
+      "feature": "occupant",
+      "value": "videofilmproduction",
+      "definition": "A business or service that can help make video/film. This could be creating, capturing, editing film. This covers both creative and commercial film production service."
+    },
+    {
+      "feature": "occupant",
+      "value": "videogamesandconsoles",
+      "definition": "A business specializing in the sale of video games, consoles and associated paraphernalia"
+    },
+    {
+      "feature": "occupant",
+      "value": "vietnamese",
+      "definition": "An establishment specializing in Vietnamese cuisine"
+    },
+    {
+      "feature": "occupant",
+      "value": "vintageclothing",
+      "definition": "A business specializing in the sale of used items, typically clothing. Often these items are older than regular second hand stores and still considered fashionable. Some stores may also offer other items besides clothing, like furniture or accessories."
+    },
+    {
+      "feature": "occupant",
+      "value": "vinylrecords",
+      "definition": "A business specializing in the sale of vinyl records"
+    },
+    {
+      "feature": "occupant",
+      "value": "virtualreality"
+    },
+    {
+      "feature": "occupant",
+      "value": "visitorcenter",
+      "definition": "A physical location that provides tourist information to visitors who tour the place or area locally. Visitor centers sometimes carry souvenirs and gifts and they can be an actual building/office, a kiosk, a booth, or a counter usually located at a specific attraction, a place of interest, airports, major bus and train terminals, or in central parts of town."
+    },
+    {
+      "feature": "occupant",
+      "value": "vitaminssupplements",
+      "definition": "A business that offers vitamins, supplements and other health related products."
+    },
+    {
+      "feature": "occupant",
+      "value": "vocalcoach",
+      "definition": "A professional offering voice (singing) lessons."
+    },
+    {
+      "feature": "occupant",
+      "value": "vocationalschool",
+      "definition": "Schools where students are trained in trades or skills to be pursued as a career."
+    },
+    {
+      "feature": "occupant",
+      "value": "waffles",
+      "definition": "A restaurant that specializes in waffles, which are leavened batter or dough cooked between two plates, patterned to give a characteristic size, shape and surface impression."
+    },
+    {
+      "feature": "occupant",
+      "value": "walkinclinic",
+      "definition": "Small medical clinics that do not require an appointment."
+    },
+    {
+      "feature": "occupant",
+      "value": "warehouse",
+      "definition": "A large building where raw materials or manufactured goods may be stored before their export or distribution for sale."
+    },
+    {
+      "feature": "occupant",
+      "value": "watches",
+      "definition": "A retailer that specializes in the sale of watches."
+    },
+    {
+      "feature": "occupant",
+      "value": "watchrepair",
+      "definition": "A company specializing in watch repair"
+    },
+    {
+      "feature": "occupant",
+      "value": "waterpark",
+      "definition": "Commercially operated parks featuring water amusement rides such as water slides and wave pools."
+    },
+    {
+      "feature": "occupant",
+      "value": "waterpurification",
+      "definition": "A business or individual that specializes in the design, installation and maintenance of water purification systems."
+    },
+    {
+      "feature": "occupant",
+      "value": "webdesign",
+      "definition": "A business or service that can help make websites. This could be designing, building, or maintaining websites."
+    },
+    {
+      "feature": "occupant",
+      "value": "weddingchappel",
+      "definition": "Venues that specialize in hosting wedding ceremonies."
+    },
+    {
+      "feature": "occupant",
+      "value": "weddingplanning",
+      "definition": "Businesses or individuals that specialize in wedding planning; can be used in conjunction with party and event planning if events other than weddings are planned."
+    },
+    {
+      "feature": "occupant",
+      "value": "weightloss",
+      "definition": "A company that offers programs and assistance managing weight loss. Business in this category should not be gyms or cosmetic surgery POIs."
+    },
+    {
+      "feature": "occupant",
+      "value": "welsh",
+      "definition": "A restaurant specializing in Welsh cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "whiskeybar",
+      "definition": "A bar or lounge that primarily serves whiskey."
+    },
+    {
+      "feature": "occupant",
+      "value": "wholesalemerchant",
+      "definition": "Companies that offer items in large quantities for sale and offer these at discounted prices."
+    },
+    {
+      "feature": "occupant",
+      "value": "wholesaler",
+      "definition": "An intermediary business or individual that buys large quantity of goods from various producers or vendors, stores them, and resells to retailers rather than to consumers. Not to be confused with a distributor, who is the sales representative of a producer."
+    },
+    {
+      "feature": "occupant",
+      "value": "wigs",
+      "definition": "A company specializing in the sale of wigs."
+    },
+    {
+      "feature": "occupant",
+      "value": "windowinstallation",
+      "definition": "A business or individual providing window replacement or repair services."
+    },
+    {
+      "feature": "occupant",
+      "value": "winebar",
+      "definition": "A venue where their primary business is serving wine to the public."
+    },
+    {
+      "feature": "occupant",
+      "value": "winery",
+      "definition": "Businesses dedicated to the production of wine, from grape cultivation to bottling, often offering tours and selling directly to the public. For wine bars, use nightlife.bars.wine_bars. For tasting rooms, use food.wineries.winetastingroom."
+    },
+    {
+      "feature": "occupant",
+      "value": "winetasting",
+      "definition": "Facilities dedicated to wine tasting. Does not include locations where wine is produced on-site, where there are grape vineyards, or where there is a bar-like setting."
+    },
+    {
+      "feature": "occupant",
+      "value": "wok",
+      "definition": "An establishment specializing in food preparation utilizing woks. A wok is a large bowl-shaped pan originating in China but commonly used in many types of contemporary Asian cuisine."
+    },
+    {
+      "feature": "occupant",
+      "value": "wraps",
+      "definition": "A food establishment offering in different types of wraps. Wraps consist of some type of filling rolled in a flatbread, such as a lavash or tortilla."
+    },
+    {
+      "feature": "occupant",
+      "value": "yoga",
+      "definition": "Facilities providing space and instruction for the practice of yoga. Do not use for businesses not offering yoga as their core instruction (e.g. a gym offering yoga once a week should not receive this category)."
+    },
+    {
+      "feature": "occupant",
+      "value": "youthclub",
+      "definition": "A place where young people can meet and participate in recreational activities."
+    },
+    {
+      "feature": "occupant",
+      "value": "yugoslav",
+      "definition": "An establishment specializing in Yugoslav cuisine."
+    },
+    {
+      "feature": "opening",
+      "value": "automobile",
+      "definition": "Models the presence and physical width of an entrance/exit that is intended for use by vehicles."
+    },
+    {
+      "feature": "opening",
+      "value": "bicycle",
+      "definition": "Models the presence and physical width of an entrance/exit that is intended for use by persons with bicycles."
+    },
+    {
+      "feature": "opening",
+      "value": "emergencyexit",
+      "definition": "Describes an Opening that is specifically intended for emergency use by the Venue Organization."
+    },
+    {
+      "feature": "opening",
+      "value": "pedestrian",
+      "definition": "Models the presence and physical extent of an entrance with or without a physical door."
+    },
+    {
+      "feature": "opening",
+      "value": "pedestrian.principal",
+      "definition": "Models the presence and physical extent of an entrance with or without a physical door."
+    },
+    {
+      "feature": "opening",
+      "value": "pedestrian.transit",
+      "definition": "Models the presence and physical extent of an entrance with or without a physical door."
+    },
+    {
+      "feature": "opening",
+      "value": "service",
+      "definition": "Should be used to model the presence and approximate point location, or approximate thematic extent of an open or semi-enclosed area, of an service operation that cannot be classified using any other \"service\" category in the hierarchy."
+    },
+    {
+      "feature": "relationship",
+      "value": "elevator",
+      "definition": "Models the presence and approximate point location of one or more elevator that offers vertical traversal capabilities."
+    },
+    {
+      "feature": "relationship",
+      "value": "escalator",
+      "definition": "Models the presence and physical extent of a single escalator that offers vertical traversal capabilities."
+    },
+    {
+      "feature": "relationship",
+      "value": "movingwalkway",
+      "definition": "Models the presence and approximate point location or physical extent of one or more neighboring moving conveyor mechanism that transports pedestrians across a horizontal or inclined plane over a short to medium distance."
+    },
+    {
+      "feature": "relationship",
+      "value": "ramp",
+      "definition": "Models the presence and approximate point location or physical extent of an incline plane."
+    },
+    {
+      "feature": "relationship",
+      "value": "stairs",
+      "definition": "Models the presence and approximate point location of one or more neighboring staircase, or the physical extent of a single staircase, that supports vertical traversal to a physically different floor that may or may not be eligible for capture as a Level."
+    },
+    {
+      "feature": "relationship",
+      "value": "traversal"
+    },
+    {
+      "feature": "relationship",
+      "value": "traversal.path"
+    },
+    {
+      "feature": "restriction",
+      "value": "employeesonly",
+      "definition": "Describes a space that is restricted to employees of the physical Venue."
+    },
+    {
+      "feature": "restriction",
+      "value": "restricted"
+    },
+    {
+      "feature": "section",
+      "value": "arcade",
+      "definition": "Facilities offering arcade games."
+    },
+    {
+      "feature": "section",
+      "value": "baggageclaim",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a baggage claim operation."
+    },
+    {
+      "feature": "section",
+      "value": "baggageclaim.intl",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a baggage claim operation dedicated to international flight operations."
+    },
+    {
+      "feature": "section",
+      "value": "carrental",
+      "definition": "A business that rents and leases motor vehicles. Businesses that rent trucks for moving and related purposes should be categorized under truck rentalservices."
+    },
+    {
+      "feature": "section",
+      "value": "carrental.dropoff",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a car rental drop-off operation."
+    },
+    {
+      "feature": "section",
+      "value": "checkin",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a collection of check-in operations."
+    },
+    {
+      "feature": "section",
+      "value": "concessions",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing concession operations."
+    },
+    {
+      "feature": "section",
+      "value": "cubicle",
+      "definition": "Models the presence and approximate thematic extent of a partially enclosed office workspace."
+    },
+    {
+      "feature": "section",
+      "value": "dutyfree",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment where a pedestrian may purchase duty free goods and services."
+    },
+    {
+      "feature": "section",
+      "value": "eatingdrinking",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment that is used as a \"common\" area for dining."
+    },
+    {
+      "feature": "section",
+      "value": "entertainmentarea",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the offering of entertainment."
+    },
+    {
+      "feature": "section",
+      "value": "entertainmentarea.game",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the offering of games, gambling, or some other playful/competitive pursuit."
+    },
+    {
+      "feature": "section",
+      "value": "entertainmentarea.music",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the offering of musical entertainment."
+    },
+    {
+      "feature": "section",
+      "value": "entertainmentarea.performance",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the offering of movie, theater or live performances."
+    },
+    {
+      "feature": "section",
+      "value": "entertainmentarea.sport",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the offering of a competitive physical activity."
+    },
+    {
+      "feature": "section",
+      "value": "exhibit",
+      "definition": "Models the presence and approximate point location of \"...an object, work of art, activity, artifact or poster designed to demonstrate a concept or show an example.\", or the approximate thematic extent of an open or semi-enclosed environment containing an exhibit."
+    },
+    {
+      "feature": "section",
+      "value": "exhibition",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing exhibits."
+    },
+    {
+      "feature": "section",
+      "value": "gambling",
+      "definition": "A business that offers placing a wager on a outcome such, such as a competitor in a sporting event or a number in a lottery."
+    },
+    {
+      "feature": "section",
+      "value": "gambling.baccarat"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.bingo"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.blackjack"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.craps"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.keno"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.mahjong"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.medalgame"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.minibaccarat"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.offtrackbetting"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.pachinko"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.paigow"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.poker"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.poker.letitride"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.poker.paigow"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.poker.threecard"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.poker.video"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.roulette"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.rummy"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.sicbo"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.slotmachine"
+    },
+    {
+      "feature": "section",
+      "value": "gambling.slotmachine.highlimit"
+    },
+    {
+      "feature": "section",
+      "value": "gatearea",
+      "definition": "Models the presence and approximate extent of an open or semi-enclosed environment containing a collection of thematically related gate holding areas."
+    },
+    {
+      "feature": "section",
+      "value": "gatearea.holding",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a single gate holding area. The function of the gate holding area is to \"hold\" persons that are expected to pass through a single boarding gate."
+    },
+    {
+      "feature": "section",
+      "value": "immigration",
+      "definition": "Models the presence and approximate point location of an immigration operation. (Also known as \"Passport Control.\")"
+    },
+    {
+      "feature": "section",
+      "value": "immigration.schengen",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing an immigration operation that \"processes\" pedestrians from multiple different countries in accordance with a legal framework that allows for a common visa policy.\n\nAlthough \"Schengen\" describes a border control arrangement that exists in Europe, the same category can be used to describe a similar legal arrangement that exists amongst other countries around the world."
+    },
+    {
+      "feature": "section",
+      "value": "information",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the offering of information."
+    },
+    {
+      "feature": "section",
+      "value": "paidarea",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as a paid area."
+    },
+    {
+      "feature": "section",
+      "value": "parkandride",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is to host a Park & Ride service."
+    },
+    {
+      "feature": "section",
+      "value": "parking",
+      "definition": "Locations that provide office space to park vehicles, usually for a fee."
+    },
+    {
+      "feature": "section",
+      "value": "parking.bicycle",
+      "definition": "A business that offers parking spaces/services for bicycles only OR a large space specifically made for parking bicycles only, with or without a fee and may or may not have onsite pesonnel. OK to use for businesses that provide bike valet services as a core offering. Please note this should only be used for locations/businesses whose core competency is bike parking. Businesses that have bike racks at/outside of their space should not be categorized under Bike Parking (they should use the Bike Parking attribute, instead). Random bike racks located on public streets/areas are ineligible for a listing."
+    },
+    {
+      "feature": "section",
+      "value": "parking.compact",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the storage of vehicles defined in the automotive industry as being \"compact.\""
+    },
+    {
+      "feature": "section",
+      "value": "parking.ev",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the storage of electric vehicles."
+    },
+    {
+      "feature": "section",
+      "value": "parking.longterm",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment  whose intended purpose is the storage of vehicles for an extended period of time."
+    },
+    {
+      "feature": "section",
+      "value": "parking.motorcycle",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed of an environment whose intended purpose is the storage of motorcycles."
+    },
+    {
+      "feature": "section",
+      "value": "parking.shortterm",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is the storage of vehicles for a short period of time."
+    },
+    {
+      "feature": "section",
+      "value": "parking.waitingarea",
+      "definition": "Models the presence and approximate point location or approximate thematic extent of an open or semi-enclosed environment whose intended purpose is use by a person (and their vehicle) to wait for the arrival of another person(s)."
+    },
+    {
+      "feature": "section",
+      "value": "platform",
+      "definition": "Models the presence and approximate point location of an individually named (or numbered) train platform."
+    },
+    {
+      "feature": "section",
+      "value": "postsecurity",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as post-security."
+    },
+    {
+      "feature": "section",
+      "value": "presecurity",
+      "definition": "Models the extent of a geofence whose area encompasses a physical environment that is describable by the Venue Organization as pre-security."
+    },
+    {
+      "feature": "section",
+      "value": "private",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment that is describable by the Venue Organization as private."
+    },
+    {
+      "feature": "section",
+      "value": "recomposearea",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment where one can restore composure or calmness. Such as when one exits a security check-point."
+    },
+    {
+      "feature": "section",
+      "value": "recreation",
+      "definition": "Business or location related to recreational activities."
+    },
+    {
+      "feature": "section",
+      "value": "rental"
+    },
+    {
+      "feature": "section",
+      "value": "retail",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment containing a retail operation."
+    },
+    {
+      "feature": "section",
+      "value": "retaildepartment",
+      "definition": "Models the presence and approximate thematic extent of an open or semi-enclosed environment that contains a particular category of products and/or services."
+    },
+    {
+      "feature": "section",
+      "value": "road",
+      "definition": "Models the presence and physical extent of an enclosed area within a physical building that is used by moving vehicles, or an open or semi-enclosed environment used by moving vehicles."
+    },
+    {
+      "feature": "section",
+      "value": "seating",
+      "definition": "models the presence and location of an open or semi-enclosed seating environment."
+    },
+    {
+      "feature": "section",
+      "value": "seatingrow",
+      "definition": "Models the presence and physical extent of a row of seats."
+    },
+    {
+      "feature": "section",
+      "value": "security",
+      "definition": "A business or organization who can be hired for private security"
+    },
+    {
+      "feature": "section",
+      "value": "servicearea"
+    },
+    {
+      "feature": "section",
+      "value": "ticketing",
+      "definition": "Models the presence and approximate point location of an automated or manned ticketing operation, or the approximate thematic extent of an area containing ticketing operations and services."
+    },
+    {
+      "feature": "section",
+      "value": "vegetation",
+      "definition": "Models the presence and physical extent of a natural or artificial vegetation feature or an open or semi-enclosed vegetative area that may or may not be prohibited from being used as a pedestrian pathway."
+    },
+    {
+      "feature": "section",
+      "value": "walkway",
+      "definition": "Models the presence and physical extent of a pedestrian pathway."
+    },
+    {
+      "feature": "unit",
+      "value": "auditorium",
+      "definition": "Models the presence and physical extent of an enclosed space that supports presentations, performances or learning."
+    },
+    {
+      "feature": "unit",
+      "value": "brick"
+    },
+    {
+      "feature": "unit",
+      "value": "classroom",
+      "definition": "Models the presence and physical extent of a learning space."
+    },
+    {
+      "feature": "unit",
+      "value": "column",
+      "definition": "Models the presence and physical extent of a floor-to-ceiling standalone column."
+    },
+    {
+      "feature": "unit",
+      "value": "concrete"
+    },
+    {
+      "feature": "unit",
+      "value": "conferenceroom",
+      "definition": "Models the following types of meeting space:\n\nSmall meeting space: An enclosed meeting space for two to four persons, suitable for both formal and informal interaction.\n\nLarge meeting space: An enclosed meeting space for five or more people, suitable for formal interaction."
+    },
+    {
+      "feature": "unit",
+      "value": "drywall"
+    },
+    {
+      "feature": "unit",
+      "value": "elevator",
+      "definition": "Models the presence and approximate point location of one or more elevator that offers vertical traversal capabilities."
+    },
+    {
+      "feature": "unit",
+      "value": "escalator",
+      "definition": "Models the presence and physical extent of a single escalator that offers vertical traversal capabilities."
+    },
+    {
+      "feature": "unit",
+      "value": "fieldofplay",
+      "definition": "Intramural sports or recreational fields usually found on college/university campus."
+    },
+    {
+      "feature": "unit",
+      "value": "firstaid",
+      "definition": "Models the presence and approximate point location of: A medical support operation or First Aid, or the physical extent of a space containing a medical support operation.."
+    },
+    {
+      "feature": "unit",
+      "value": "fitnessroom",
+      "definition": "<odels the presence and physical extent of an exercise/training room."
+    },
+    {
+      "feature": "unit",
+      "value": "foodservice",
+      "definition": "Models the presence and approximate point location of a foodservice operation where a pedestrian can enjoy food and drink. The foodservice is offered by a foodservice company."
+    },
+    {
+      "feature": "unit",
+      "value": "footbridge",
+      "definition": "Models the presence and physical extent of an open, semi- or enclosed footbridge that connects Buildings."
+    },
+    {
+      "feature": "unit",
+      "value": "glass"
+    },
+    {
+      "feature": "unit",
+      "value": "huddleroom",
+      "definition": "Models the presence and physical extent of an enclosed meeting space suitable for ad hoc, informal meetings."
+    },
+    {
+      "feature": "unit",
+      "value": "kitchen"
+    },
+    {
+      "feature": "unit",
+      "value": "laboratory",
+      "definition": "Models the presence and physical extent of an enclosed space that provides controlled conditions in which scientific or technological research, experiments, and measurement may be performed."
+    },
+    {
+      "feature": "unit",
+      "value": "library",
+      "definition": "A building or room where media is collected for people to read, borrow, and reference. Traditionally this is mostly books, but may also include other media too."
+    },
+    {
+      "feature": "unit",
+      "value": "lobby",
+      "definition": "Models the presence and physical extent of an enclosed foyer or entrance hall."
+    },
+    {
+      "feature": "unit",
+      "value": "lounge",
+      "definition": "Models the presence and physical extent of a space where people can sit and relax."
+    },
+    {
+      "feature": "unit",
+      "value": "mailroom",
+      "definition": "Models the presence and physical extent of an enclosed space where: Incoming and outgoing mail is processed and sorted. Incoming/outgoing mail is dropped-off/picked up."
+    },
+    {
+      "feature": "unit",
+      "value": "mothersroom",
+      "definition": "Models the presence and approximate point or physical extent of an enclosed space where a woman may breastfeed or use a breast pump in private."
+    },
+    {
+      "feature": "unit",
+      "value": "movietheater",
+      "definition": "Models the presence and physical extent of a room used to view films."
+    },
+    {
+      "feature": "unit",
+      "value": "movingwalkway",
+      "definition": "Models the presence and approximate point location or physical extent of one or more neighboring moving conveyor mechanism that transports pedestrians across a horizontal or inclined plane over a short to medium distance."
+    },
+    {
+      "feature": "unit",
+      "value": "nonpublic",
+      "definition": "An area/space that contains operational, administrative, and/or management functions whose environments, if mapped, would have little or no relevance from a pedestrian standpoint."
+    },
+    {
+      "feature": "unit",
+      "value": "office",
+      "definition": "Models the presence and physical extent of an enclosed work space. \"office\" models:\n\nA private office: An enclosed work space for one person, suitable for activities which are confidential, demand a lot of concentration or include many small meetings.\n\nA shared office: An enclosed work space for two or three people, suitable for semi-concentrated work and collaborative work in small groups.\n\nA team room: An enclosed work space for four to ten people; suitable for teamwork which may be confidential and demands frequent internal communication."
+    },
+    {
+      "feature": "unit",
+      "value": "opentobelow",
+      "definition": "Models the presence and physical extent of a vertical \"column\" of air that is visible to a pedestrian, and which extends through one or more floor of a physical building."
+    },
+    {
+      "feature": "unit",
+      "value": "parking",
+      "definition": "Locations that provide office space to park vehicles, usually for a fee."
+    },
+    {
+      "feature": "unit",
+      "value": "phoneroom",
+      "definition": "Models the presence and physical extent of a physically enclosed space intended for phone calls."
+    },
+    {
+      "feature": "unit",
+      "value": "platform",
+      "definition": "Models the presence and approximate point location of an individually named (or numbered) train platform."
+    },
+    {
+      "feature": "unit",
+      "value": "privatelounge",
+      "definition": "Models the presence and physical extent of an enclosed space that is made available to authorized pedestrians."
+    },
+    {
+      "feature": "unit",
+      "value": "ramp",
+      "definition": "Models the presence and approximate point location or physical extent of an incline plane."
+    },
+    {
+      "feature": "unit",
+      "value": "recreation",
+      "definition": "Business or location related to recreational activities."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom",
+      "definition": "Models the presence and approximate point location of one or more neighboring spaces, or the physical extent of a single enclosed space, containing bathroom facilities."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.family",
+      "definition": "A bathroom intended for family use"
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.female",
+      "definition": "A bathroom intended for female use"
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.female.wheelchair",
+      "definition": "Models the presence and approximate point location of a female bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.male",
+      "definition": "A bathroom intended for male use"
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.male.wheelchair",
+      "definition": "Models the presence and approximate point location of a male bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.transgender",
+      "definition": "Models the presence and approximate point location of one or more neighboring spaces, or the physical extent of a single space, containing bathroom facilities that are intended for use by a person that identifies themselves as transgender."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.transgender.wheelchair",
+      "definition": "Models the presence and approximate point location of a transgender bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.unisex",
+      "definition": "Models the presence and approximate point location of one or more neighboring spaces, or the physical extent of a single space, containing bathroom facilities that are intended for use by any person."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.unisex.wheelchair",
+      "definition": "Models the presence and approximate point location of a unisex bathroom facility that is entirely dedicated to persons with a disability."
+    },
+    {
+      "feature": "unit",
+      "value": "restroom.wheelchair",
+      "definition": "Dedicated restroom designed to be accessible for those with physical disabilities."
+    },
+    {
+      "feature": "unit",
+      "value": "road",
+      "definition": "Models the presence and physical extent of an enclosed area within a physical building that is used by moving vehicles, or an open or semi-enclosed environment used by moving vehicles."
+    },
+    {
+      "feature": "unit",
+      "value": "room",
+      "definition": "Models a \"...distinguishable space within a structure. Usually, a room is separated from other spaces or passageways by interior walls; moreover, it is separated from outdoor areas by an exterior wall, sometimes with a door.\""
+    },
+    {
+      "feature": "unit",
+      "value": "serverroom",
+      "definition": "Models the presence and physical extent of an enclosed space devoted to the operation of computer servers."
+    },
+    {
+      "feature": "unit",
+      "value": "shower",
+      "definition": "Models the presence and approximate point location of one or more neighboring shower facility and adjoining locker/changing area, or the physical extent of an enclosed space that provides shower facilities and adjoining locker/changing area."
+    },
+    {
+      "feature": "unit",
+      "value": "smokingarea",
+      "definition": "Models the presence and approximate point location, or physical extent of a space containing a smoking area or facility."
+    },
+    {
+      "feature": "unit",
+      "value": "stairs",
+      "definition": "Models the presence and approximate point location of one or more neighboring staircase, or the physical extent of a single staircase, that supports vertical traversal to a physically different floor that may or may not be eligible for capture as a Level."
+    },
+    {
+      "feature": "unit",
+      "value": "steps",
+      "definition": "Models the presence and physical extent of a series of steps that support vertical traversal on a physical floor of variable height. Despite the variable height, the physical floor is modeled as a single Level."
+    },
+    {
+      "feature": "unit",
+      "value": "storage",
+      "definition": "Models the presence and approximate point location of a storage facility."
+    },
+    {
+      "feature": "unit",
+      "value": "structure",
+      "definition": "Models the presence and physical extent of a network of floor-to-ceiling walls or an integrated system of walls and columns."
+    },
+    {
+      "feature": "unit",
+      "value": "terrace"
+    },
+    {
+      "feature": "unit",
+      "value": "theater",
+      "definition": "Groups or locations featuring live performance arts in fields such as music, theater, and dance."
+    },
+    {
+      "feature": "unit",
+      "value": "unenclosedarea",
+      "definition": "Models the presence and approximate point location of a physical object or service that cannot be classified using any other category, or whose utilization is unknown."
+    },
+    {
+      "feature": "unit",
+      "value": "unspecified",
+      "definition": "Models the presence and approximate point location of a physical object or service that cannot be classified using any other category, or whose utilization is unknown."
+    },
+    {
+      "feature": "unit",
+      "value": "vegetation",
+      "definition": "Models the presence and physical extent of a natural or artificial vegetation feature or an open or semi-enclosed vegetative area that may or may not be prohibited from being used as a pedestrian pathway."
+    },
+    {
+      "feature": "unit",
+      "value": "waitingroom"
+    },
+    {
+      "feature": "unit",
+      "value": "walkway",
+      "definition": "Models the presence and physical extent of a pedestrian pathway."
+    },
+    {
+      "feature": "unit",
+      "value": "walkway.island"
+    },
+    {
+      "feature": "unit",
+      "value": "wood"
+    },
+    {
+      "feature": "venue",
+      "value": "airport",
+      "definition": "A facility or complex where airplanes can regularly take off and land."
+    },
+    {
+      "feature": "venue",
+      "value": "airport.intl",
+      "definition": "A  facility for the landing, takeoff, shelter, supply, and repair of aircrafts that offers customs and immigration facilities for passengers travelling between countries."
+    },
+    {
+      "feature": "venue",
+      "value": "aquarium",
+      "definition": "Facilities exhibiting aquatic enclosures of fish and marine life. Can be cross-categorized with Zoos."
+    },
+    {
+      "feature": "venue",
+      "value": "businesscampus",
+      "definition": "A collection of multiple commercial buildings where business is operated from them"
+    },
+    {
+      "feature": "venue",
+      "value": "casino",
+      "definition": "Venues hosting legalized gambling. Includes games of chance and sports betting."
+    },
+    {
+      "feature": "venue",
+      "value": "communitycenter",
+      "definition": "A space maintained by the local community, that is host to social, educational and recreational activities."
+    },
+    {
+      "feature": "venue",
+      "value": "conventioncenter",
+      "definition": "A convention center is a large building that is designed to hold a convention, where individuals and groups gather to promote and share common interests. Convention centers typically offer sufficient floor area to accommodate several thousand attendees. Synonym: exhibition center"
+    },
+    {
+      "feature": "venue",
+      "value": "governmentfacility"
+    },
+    {
+      "feature": "venue",
+      "value": "healthcarefacility"
+    },
+    {
+      "feature": "venue",
+      "value": "hotel",
+      "definition": "Businesses providing short-term lodging, that typically have a staff that cleans and maintains rooms for its guests."
+    },
+    {
+      "feature": "venue",
+      "value": "museum",
+      "definition": "Facilities dedicated to the collection, preservation, and display of items of historical, artisic, or scientic value."
+    },
+    {
+      "feature": "venue",
+      "value": "parkingfacility",
+      "definition": "Enclosed parking structure."
+    },
+    {
+      "feature": "venue",
+      "value": "resort",
+      "definition": "A self-contained commercial destination which provide for most of a guest's wants while remaining on the premises, such as food, drink, lodging, sports, entertainment, and shopping. Usually a resort is based around a particular purpose or theme that serves as the primary attraction for visitors."
+    },
+    {
+      "feature": "venue",
+      "value": "retailstore"
+    },
+    {
+      "feature": "venue",
+      "value": "shoppingcenter",
+      "definition": "A complex containing several retail businesses. Usually accompanied with parking and food courts and or restaurants."
+    },
+    {
+      "feature": "venue",
+      "value": "stadium",
+      "definition": "A Sports Complex consists of more than one sports venue in the same general location sharing common grounds, parking, etc., and has a formal name.  The Meadowlands Sports Complex in New Jersey consists of Metlife Stadium, Izod Center, and Meadowlands Racetrack."
+    },
+    {
+      "feature": "venue",
+      "value": "stripmall",
+      "definition": "Suburban plaza or strip mall which contains a variety of local stores and / or branded stores."
+    },
+    {
+      "feature": "venue",
+      "value": "theater",
+      "definition": "Groups or locations featuring live performance arts in fields such as music, theater, and dance."
+    },
+    {
+      "feature": "venue",
+      "value": "themepark"
+    },
+    {
+      "feature": "venue",
+      "value": "trainstation",
+      "definition": "A location where one could expect to either board or alight from a train."
+    },
+    {
+      "feature": "venue",
+      "value": "transitstation"
+    },
+    {
+      "feature": "venue",
+      "value": "university"
+    }
+  ]
+}

--- a/IMDFlex/Projects/Data/Sources/DataSources/IMDFCategoryCatalogJSONLoader.swift
+++ b/IMDFlex/Projects/Data/Sources/DataSources/IMDFCategoryCatalogJSONLoader.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Domain
+
+public final class IMDFCategoryCatalogJSONLoader: IMDFCategoryCatalogLoading, Sendable {
+    private let resourceName: String
+    private let bundle: Bundle
+    private let decoder: JSONDecoder
+
+    public init(
+        resourceName: String = "IMDFCategoryCatalog.generated",
+        bundle: Bundle? = nil,
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.resourceName = resourceName
+        self.bundle = bundle ?? .imdfCategoryCatalogResources
+        self.decoder = decoder
+    }
+
+    public func loadCatalog() async throws -> IMDFCategoryCatalog {
+        guard let url = bundle.url(forResource: resourceName, withExtension: "json") else {
+            throw IMDFCategoryCatalogLoadingError.resourceNotFound(resourceName: resourceName)
+        }
+
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(IMDFCategoryCatalog.self, from: data)
+    }
+}
+
+public enum IMDFCategoryCatalogLoadingError: Error, Equatable, Sendable {
+    case resourceNotFound(resourceName: String)
+}
+
+private final class IMDFCategoryCatalogBundleToken {}
+
+private extension Bundle {
+    static var imdfCategoryCatalogResources: Bundle {
+        Bundle(for: IMDFCategoryCatalogBundleToken.self)
+    }
+}

--- a/IMDFlex/Projects/Data/Tests/IMDFCategoryCatalogJSONLoaderTests.swift
+++ b/IMDFlex/Projects/Data/Tests/IMDFCategoryCatalogJSONLoaderTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import XCTest
+@testable import Data
+import Domain
+
+final class IMDFCategoryCatalogJSONLoaderTests: XCTestCase {
+    func test_whenGeneratedCatalogIsLoaded_thenItMatchesOfficialFeatureCounts() async throws {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        let catalog = try await sut.loadCatalog()
+        let countsByFeature = Dictionary(
+            uniqueKeysWithValues: IMDFCategoryFeature.allCases.map { feature in
+                (feature, catalog.entries(for: feature).count)
+            }
+        )
+
+        // Then
+        for summary in IMDFCategoryCatalogSource.appleCategories20210728FeatureSummaries {
+            XCTAssertEqual(countsByFeature[summary.feature], summary.categoryCount, "Unexpected count for \(summary.feature.rawValue)")
+        }
+    }
+
+    func test_whenGeneratedCatalogIsLoaded_thenItContainsRepresentativeRawValues() async throws {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        let catalog = try await sut.loadCatalog()
+
+        // Then
+        XCTAssertTrue(catalog.contains("shoppingcenter", for: .venue))
+        XCTAssertTrue(catalog.contains("drinkingfountain", for: .amenity))
+        XCTAssertTrue(catalog.contains("corporateoffices", for: .occupant))
+        XCTAssertTrue(catalog.contains("traversal.path", for: .relationship))
+        XCTAssertTrue(catalog.contains("gatearea", for: .section))
+    }
+
+    func test_whenGeneratedCatalogIsLoaded_thenDefinitionsArePreservedWhenAvailable() async throws {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        let catalog = try await sut.loadCatalog()
+        let accessibilityEntry = try XCTUnwrap(
+            catalog.entries(for: .accessibility).first { $0.value == "braille" }
+        )
+
+        // Then
+        XCTAssertFalse(accessibilityEntry.definition?.isEmpty ?? true)
+    }
+
+    func test_whenResourceIsMissing_thenLoaderThrowsResourceNotFound() async throws {
+        // Given
+        let sut = makeSUT(resourceName: "MissingIMDFCategoryCatalog")
+
+        // When
+        do {
+            _ = try await sut.loadCatalog()
+            XCTFail("Expected resourceNotFound error.")
+        } catch let error as IMDFCategoryCatalogLoadingError {
+            // Then
+            XCTAssertEqual(error, .resourceNotFound(resourceName: "MissingIMDFCategoryCatalog"))
+        } catch {
+            XCTFail("Expected IMDFCategoryCatalogLoadingError, got \(error).")
+        }
+    }
+
+    private func makeSUT(resourceName: String = "IMDFCategoryCatalog.generated") -> IMDFCategoryCatalogJSONLoader {
+        IMDFCategoryCatalogJSONLoader(resourceName: resourceName)
+    }
+}

--- a/IMDFlex/Projects/Domain/Sources/UseCases/Protocols.swift
+++ b/IMDFlex/Projects/Domain/Sources/UseCases/Protocols.swift
@@ -12,3 +12,8 @@ public protocol ProjectRepositoryProtocol: Sendable {
 public protocol IMDFExporterProtocol: Sendable {
     func export(_ venue: Venue) async throws -> Data
 }
+
+/// IMDF category catalog loading protocol implemented by the Data layer.
+public protocol IMDFCategoryCatalogLoading: Sendable {
+    func loadCatalog() async throws -> IMDFCategoryCatalog
+}

--- a/docs/imdf-category-catalog.md
+++ b/docs/imdf-category-catalog.md
@@ -52,11 +52,22 @@ This avoids generating huge Swift enums for sets such as `occupant` while still 
 - `IMDFCategoryCatalog`: lookup by feature and raw value.
 - `IMDFCategoryCatalogSource.appleCategories20210728FeatureSummaries`: official count summaries and representative values used by tests.
 
-The full CSV is not bundled into the app yet.
+The full catalog is stored as generated JSON:
+
+- Resource: `IMDFlex/Projects/Data/Resources/IMDFCategoryCatalog.generated.json`
+- Loader: `IMDFCategoryCatalogJSONLoader`
+- Generated distinct entries: 1,533
+
+Regenerate it from the Apple CSV with:
+
+```bash
+python3 scripts/generate_imdf_category_catalog_json.py \
+  /Users/luminoux/Downloads/IMDF/categories_20210728.csv \
+  IMDFlex/Projects/Data/Resources/IMDFCategoryCatalog.generated.json
+```
 
 ## Next Steps
 
-1. Decide whether the full catalog should be stored as a bundled CSV/JSON resource or generated Swift data.
-2. Add a parser/loader in `Data` if bundling a CSV or JSON resource.
-3. Let Presentation category pickers query the catalog by feature type.
-4. Gradually allow Domain feature categories to preserve raw strings in addition to curated enum presets.
+1. Let Presentation category pickers query the catalog by feature type.
+2. Add search/filter behavior using `localizedStandardContains()` for user-facing category selection.
+3. Gradually allow Domain feature categories to preserve raw strings in addition to curated enum presets.

--- a/scripts/generate_imdf_category_catalog_json.py
+++ b/scripts/generate_imdf_category_catalog_json.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+import csv
+import json
+import sys
+from collections import OrderedDict
+from pathlib import Path
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: generate_imdf_category_catalog_json.py <categories_csv> <output_json>", file=sys.stderr)
+        return 2
+
+    csv_path = Path(sys.argv[1])
+    output_path = Path(sys.argv[2])
+    entries_by_id: OrderedDict[str, dict[str, str]] = OrderedDict()
+
+    with csv_path.open(newline="", encoding="utf-8-sig") as csv_file:
+        reader = csv.DictReader(csv_file)
+
+        for row in reader:
+            feature = row["feature"].strip()
+            value = row["category"].strip()
+            definition = row["definition"].strip()
+            entry_id = f"{feature}:{value}"
+
+            if entry_id not in entries_by_id:
+                entry = {
+                    "feature": feature,
+                    "value": value,
+                }
+                if definition:
+                    entry["definition"] = definition
+                entries_by_id[entry_id] = entry
+            elif definition and "definition" not in entries_by_id[entry_id]:
+                entries_by_id[entry_id]["definition"] = definition
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as output_file:
+        json.dump({"entries": list(entries_by_id.values())}, output_file, ensure_ascii=False, indent=2)
+        output_file.write("\n")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Adds a generated JSON IMDF category catalog resource and a Data-layer loader for runtime category lookup.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Generated `IMDFCategoryCatalog.generated.json` from Apple's `categories_20210728.csv`.
- Added `IMDFCategoryCatalogLoading` in Domain and `IMDFCategoryCatalogJSONLoader` in Data.
- Added Data tests for feature counts, representative raw values, preserved definitions, and missing resource errors.
- Added a reproducible generation script at `scripts/generate_imdf_category_catalog_json.py`.
- Updated Data resources configuration and category catalog documentation.

## IMDF Impact

- IMDFlex can now load 1,533 distinct Apple category entries from generated JSON.
- Existing curated category enums and exporter behavior are unchanged.
- This enables future category picker/search UI without generating huge Swift enums.

## Architecture Notes

- Domain owns the loader protocol and catalog value types.
- Data owns bundled resource loading and JSON decoding.
- Presentation remains untouched and will consume the catalog through a protocol in a later PR.
- No third-party dependencies were added.

## Verification

- [x] `Domain`: `mise exec -- tuist test Domain` passed, 21 tests.
- [x] `Data`: `mise exec -- tuist test Data` passed, 11 tests.
- [x] `Presentation`: compiled through `mise exec -- tuist build IMDFlex`.
- [x] `DesignSystem`: included in `mise exec -- tuist build IMDFlex`.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [x] `mise exec -- tuist generate --no-binary-cache --no-open`: passed.
- [ ] Apple IMDF Validator / preflight: not run; category catalog loading only.

## Screenshots Or Recording

Not applicable; no UI changes.

## Related Issues

Closes #27

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
