### PR TITLE
feat: add feature authoring tool state

### DIFF
--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/FeatureAuthoringToolState.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/FeatureAuthoringToolState.swift
@@ -1,0 +1,244 @@
+import Domain
+import Foundation
+import Observation
+
+public enum IMDFAuthoringGeometry: String, Codable, CaseIterable, Hashable, Sendable {
+    case point
+    case line
+    case polygon
+    case form
+
+    public var minimumPointCount: Int {
+        switch self {
+        case .point: 1
+        case .line: 2
+        case .polygon: 3
+        case .form: 0
+        }
+    }
+}
+
+public enum IMDFAuthoringReference: String, Codable, CaseIterable, Hashable, Sendable {
+    case building
+    case level
+    case unit
+    case anchor
+    case levelOrBuilding
+    case relationshipEndpoints
+}
+
+public enum IMDFAuthoringFeature: String, Codable, CaseIterable, Hashable, Identifiable, Sendable {
+    case address
+    case venue
+    case building
+    case footprint
+    case level
+    case unit
+    case opening
+    case amenity
+    case anchor
+    case occupant
+    case detail
+    case fixture
+    case geofence
+    case kiosk
+    case relationship
+    case section
+
+    public var id: String { rawValue }
+
+    public var contract: IMDFAuthoringContract {
+        switch self {
+        case .address:
+            .init(feature: self, geometry: .form)
+        case .venue:
+            .init(feature: self, geometry: .polygon, requiresCategory: true, categoryFeature: .venue)
+        case .building:
+            .init(feature: self, geometry: .form, requiresCategory: true, categoryFeature: .building)
+        case .footprint:
+            .init(
+                feature: self,
+                geometry: .polygon,
+                requiresCategory: true,
+                requiredReferences: [.building],
+                categoryFeature: .footprint
+            )
+        case .level:
+            .init(
+                feature: self,
+                geometry: .polygon,
+                requiresCategory: true,
+                requiredReferences: [.building],
+                categoryFeature: .level
+            )
+        case .unit:
+            .init(
+                feature: self,
+                geometry: .polygon,
+                requiresCategory: true,
+                requiredReferences: [.level],
+                categoryFeature: .unit
+            )
+        case .opening:
+            .init(
+                feature: self,
+                geometry: .line,
+                requiresCategory: true,
+                requiredReferences: [.level],
+                categoryFeature: .opening
+            )
+        case .amenity:
+            .init(
+                feature: self,
+                geometry: .point,
+                requiresCategory: true,
+                requiredReferences: [.unit],
+                categoryFeature: .amenity
+            )
+        case .anchor:
+            .init(feature: self, geometry: .point, requiredReferences: [.unit])
+        case .occupant:
+            .init(
+                feature: self,
+                geometry: .form,
+                requiresCategory: true,
+                requiredReferences: [.anchor],
+                categoryFeature: .occupant
+            )
+        case .detail:
+            .init(feature: self, geometry: .line, requiredReferences: [.level])
+        case .fixture:
+            .init(
+                feature: self,
+                geometry: .polygon,
+                requiresCategory: true,
+                requiredReferences: [.level],
+                categoryFeature: .fixture
+            )
+        case .geofence:
+            .init(
+                feature: self,
+                geometry: .polygon,
+                requiresCategory: true,
+                requiredReferences: [.levelOrBuilding],
+                categoryFeature: .geofence
+            )
+        case .kiosk:
+            .init(feature: self, geometry: .polygon, requiredReferences: [.level])
+        case .relationship:
+            .init(
+                feature: self,
+                geometry: .form,
+                requiresCategory: true,
+                requiredReferences: [.relationshipEndpoints],
+                categoryFeature: .relationship
+            )
+        case .section:
+            .init(
+                feature: self,
+                geometry: .polygon,
+                requiresCategory: true,
+                requiredReferences: [.level],
+                categoryFeature: .section
+            )
+        }
+    }
+}
+
+public struct IMDFAuthoringContract: Codable, Equatable, Sendable {
+    public let feature: IMDFAuthoringFeature
+    public let geometry: IMDFAuthoringGeometry
+    public let requiresCategory: Bool
+    public let requiredReferences: [IMDFAuthoringReference]
+    public let categoryFeature: IMDFCategoryFeature?
+
+    public init(
+        feature: IMDFAuthoringFeature,
+        geometry: IMDFAuthoringGeometry,
+        requiresCategory: Bool = false,
+        requiredReferences: [IMDFAuthoringReference] = [],
+        categoryFeature: IMDFCategoryFeature? = nil
+    ) {
+        self.feature = feature
+        self.geometry = geometry
+        self.requiresCategory = requiresCategory
+        self.requiredReferences = requiredReferences
+        self.categoryFeature = categoryFeature
+    }
+}
+
+@MainActor
+@Observable
+public final class FeatureAuthoringToolState {
+    public private(set) var selectedFeature: IMDFAuthoringFeature
+    public private(set) var draftedPointCount: Int
+    public private(set) var hasSelectedCategory: Bool
+    public private(set) var satisfiedReferences: Set<IMDFAuthoringReference>
+
+    public init(
+        selectedFeature: IMDFAuthoringFeature = .unit,
+        draftedPointCount: Int = 0,
+        hasSelectedCategory: Bool = false,
+        satisfiedReferences: Set<IMDFAuthoringReference> = []
+    ) {
+        self.selectedFeature = selectedFeature
+        self.draftedPointCount = draftedPointCount
+        self.hasSelectedCategory = hasSelectedCategory
+        self.satisfiedReferences = satisfiedReferences
+    }
+
+    public var contract: IMDFAuthoringContract {
+        selectedFeature.contract
+    }
+
+    public var canFinish: Bool {
+        hasEnoughGeometry && hasRequiredCategory && hasRequiredReferences
+    }
+
+    public func selectFeature(_ feature: IMDFAuthoringFeature) {
+        selectedFeature = feature
+        resetDraft()
+    }
+
+    public func addDraftPoint() {
+        draftedPointCount += 1
+    }
+
+    public func removeLastDraftPoint() {
+        draftedPointCount = max(0, draftedPointCount - 1)
+    }
+
+    public func setCategorySelected(_ isSelected: Bool) {
+        hasSelectedCategory = isSelected
+    }
+
+    public func satisfyReference(_ reference: IMDFAuthoringReference) {
+        satisfiedReferences.insert(reference)
+    }
+
+    public func clearReference(_ reference: IMDFAuthoringReference) {
+        satisfiedReferences.remove(reference)
+    }
+
+    public func cancel() {
+        resetDraft()
+    }
+
+    private var hasEnoughGeometry: Bool {
+        draftedPointCount >= contract.geometry.minimumPointCount
+    }
+
+    private var hasRequiredCategory: Bool {
+        !contract.requiresCategory || hasSelectedCategory
+    }
+
+    private var hasRequiredReferences: Bool {
+        Set(contract.requiredReferences).isSubset(of: satisfiedReferences)
+    }
+
+    private func resetDraft() {
+        draftedPointCount = 0
+        hasSelectedCategory = false
+        satisfiedReferences = []
+    }
+}

--- a/IMDFlex/Projects/Presentation/Tests/FeatureAuthoringToolStateTests.swift
+++ b/IMDFlex/Projects/Presentation/Tests/FeatureAuthoringToolStateTests.swift
@@ -1,0 +1,173 @@
+import XCTest
+@testable import Presentation
+import Domain
+
+@MainActor
+final class FeatureAuthoringToolStateTests: XCTestCase {
+    func test_whenAllFeaturesAreListed_thenTheyCoverAllMVPAuthoringFeatures() {
+        // Given
+        let features = IMDFAuthoringFeature.allCases
+
+        // When
+        let featureNames = features.map(\.rawValue)
+
+        // Then
+        XCTAssertEqual(
+            featureNames,
+            [
+                "address",
+                "venue",
+                "building",
+                "footprint",
+                "level",
+                "unit",
+                "opening",
+                "amenity",
+                "anchor",
+                "occupant",
+                "detail",
+                "fixture",
+                "geofence",
+                "kiosk",
+                "relationship",
+                "section"
+            ]
+        )
+    }
+
+    func test_whenFeatureContractsAreRead_thenTheyExposeGeometryCategoryAndCatalogMapping() {
+        // Given
+        let unit = IMDFAuthoringFeature.unit.contract
+        let opening = IMDFAuthoringFeature.opening.contract
+        let amenity = IMDFAuthoringFeature.amenity.contract
+        let occupant = IMDFAuthoringFeature.occupant.contract
+        let relationship = IMDFAuthoringFeature.relationship.contract
+
+        // When
+        let geometryByFeature = [
+            unit.feature: unit.geometry,
+            opening.feature: opening.geometry,
+            amenity.feature: amenity.geometry,
+            occupant.feature: occupant.geometry,
+            relationship.feature: relationship.geometry
+        ]
+
+        // Then
+        XCTAssertEqual(geometryByFeature[.unit], .polygon)
+        XCTAssertEqual(geometryByFeature[.opening], .line)
+        XCTAssertEqual(geometryByFeature[.amenity], .point)
+        XCTAssertEqual(geometryByFeature[.occupant], .form)
+        XCTAssertEqual(geometryByFeature[.relationship], .form)
+        XCTAssertEqual(unit.categoryFeature, .unit)
+        XCTAssertEqual(opening.categoryFeature, .opening)
+        XCTAssertEqual(amenity.categoryFeature, .amenity)
+        XCTAssertEqual(occupant.categoryFeature, .occupant)
+        XCTAssertEqual(relationship.categoryFeature, .relationship)
+    }
+
+    func test_whenFeatureRequiresReferences_thenContractExposesRequiredReferences() {
+        // Given
+        let footprint = IMDFAuthoringFeature.footprint.contract
+        let unit = IMDFAuthoringFeature.unit.contract
+        let anchor = IMDFAuthoringFeature.anchor.contract
+        let geofence = IMDFAuthoringFeature.geofence.contract
+        let relationship = IMDFAuthoringFeature.relationship.contract
+
+        // When
+        let referencesByFeature = [
+            footprint.feature: footprint.requiredReferences,
+            unit.feature: unit.requiredReferences,
+            anchor.feature: anchor.requiredReferences,
+            geofence.feature: geofence.requiredReferences,
+            relationship.feature: relationship.requiredReferences
+        ]
+
+        // Then
+        XCTAssertEqual(referencesByFeature[.footprint], [.building])
+        XCTAssertEqual(referencesByFeature[.unit], [.level])
+        XCTAssertEqual(referencesByFeature[.anchor], [.unit])
+        XCTAssertEqual(referencesByFeature[.geofence], [.levelOrBuilding])
+        XCTAssertEqual(referencesByFeature[.relationship], [.relationshipEndpoints])
+    }
+
+    func test_whenPolygonFeatureHasTooFewPoints_thenStateCannotFinish() {
+        // Given
+        let sut = makeSUT(selectedFeature: .unit)
+        sut.setCategorySelected(true)
+        sut.satisfyReference(.level)
+
+        // When
+        sut.addDraftPoint()
+        sut.addDraftPoint()
+
+        // Then
+        XCTAssertFalse(sut.canFinish)
+    }
+
+    func test_whenPolygonFeatureHasRequiredCategoryReferenceAndPoints_thenStateCanFinish() {
+        // Given
+        let sut = makeSUT(selectedFeature: .unit)
+
+        // When
+        sut.setCategorySelected(true)
+        sut.satisfyReference(.level)
+        sut.addDraftPoint()
+        sut.addDraftPoint()
+        sut.addDraftPoint()
+
+        // Then
+        XCTAssertTrue(sut.canFinish)
+    }
+
+    func test_whenFormFeatureHasRequiredCategoryAndReference_thenStateCanFinishWithoutPoints() {
+        // Given
+        let sut = makeSUT(selectedFeature: .occupant)
+
+        // When
+        sut.setCategorySelected(true)
+        sut.satisfyReference(.anchor)
+
+        // Then
+        XCTAssertTrue(sut.canFinish)
+        XCTAssertEqual(sut.draftedPointCount, 0)
+    }
+
+    func test_whenFeatureSelectionChanges_thenDraftStateIsReset() {
+        // Given
+        let sut = makeSUT(selectedFeature: .unit)
+        sut.setCategorySelected(true)
+        sut.satisfyReference(.level)
+        sut.addDraftPoint()
+        sut.addDraftPoint()
+
+        // When
+        sut.selectFeature(.amenity)
+
+        // Then
+        XCTAssertEqual(sut.selectedFeature, .amenity)
+        XCTAssertEqual(sut.draftedPointCount, 0)
+        XCTAssertFalse(sut.hasSelectedCategory)
+        XCTAssertTrue(sut.satisfiedReferences.isEmpty)
+    }
+
+    func test_whenDraftIsCancelled_thenSelectionIsKeptAndDraftStateIsReset() {
+        // Given
+        let sut = makeSUT(selectedFeature: .opening)
+        sut.setCategorySelected(true)
+        sut.satisfyReference(.level)
+        sut.addDraftPoint()
+
+        // When
+        sut.cancel()
+
+        // Then
+        XCTAssertEqual(sut.selectedFeature, .opening)
+        XCTAssertEqual(sut.draftedPointCount, 0)
+        XCTAssertFalse(sut.hasSelectedCategory)
+        XCTAssertTrue(sut.satisfiedReferences.isEmpty)
+    }
+
+    private func makeSUT(selectedFeature: IMDFAuthoringFeature = .unit) -> FeatureAuthoringToolState {
+        FeatureAuthoringToolState(selectedFeature: selectedFeature)
+    }
+}

--- a/docs/feature-authoring-tool-state.md
+++ b/docs/feature-authoring-tool-state.md
@@ -1,0 +1,64 @@
+# Feature Authoring Tool State
+
+This document records the first Presentation-layer authoring contract for IMDFlex.
+
+## Purpose
+
+`FeatureAuthoringToolState` defines what the editor is currently authoring before MapKit gestures or concrete Domain mutations are added.
+
+The state is intentionally UI-independent and small:
+
+- selected IMDF feature
+- authoring geometry
+- drafted point count
+- category selection status
+- required reference satisfaction
+- finish/cancel behavior
+
+It should not own MapKit camera state, selected Domain objects, category picker search, or persistence.
+
+## Geometry Modes
+
+| Geometry | Minimum drafted points | Examples |
+| --- | ---: | --- |
+| `point` | 1 | `amenity`, `anchor` |
+| `line` | 2 | `opening`, `detail` |
+| `polygon` | 3 | `venue`, `unit`, `fixture`, `section` |
+| `form` | 0 | `address`, `building`, `occupant`, `relationship` |
+
+## Feature Contracts
+
+| Feature | Geometry | Category | Required references |
+| --- | --- | --- | --- |
+| `address` | `form` | No | None |
+| `venue` | `polygon` | `venue` | None |
+| `building` | `form` | `building` | None |
+| `footprint` | `polygon` | `footprint` | `building` |
+| `level` | `polygon` | `level` | `building` |
+| `unit` | `polygon` | `unit` | `level` |
+| `opening` | `line` | `opening` | `level` |
+| `amenity` | `point` | `amenity` | `unit` |
+| `anchor` | `point` | No | `unit` |
+| `occupant` | `form` | `occupant` | `anchor` |
+| `detail` | `line` | No | `level` |
+| `fixture` | `polygon` | `fixture` | `level` |
+| `geofence` | `polygon` | `geofence` | `levelOrBuilding` |
+| `kiosk` | `polygon` | No | `level` |
+| `relationship` | `form` | `relationship` | `relationshipEndpoints` |
+| `section` | `polygon` | `section` | `level` |
+
+## Progressive Disclosure
+
+This model should stay focused. Add complexity through adjacent models instead of growing one large editor object:
+
+- Category picker/search belongs in a category picker model.
+- Map point storage belongs in a drawing draft model.
+- Domain feature mutation belongs in an editor use case/coordinator.
+- Inspector field editing belongs in feature-specific inspector state.
+
+## Next Steps
+
+1. Build an editor shell that reads `IMDFAuthoringFeature` and `IMDFAuthoringGeometry`.
+2. Add a category picker model that uses `categoryFeature`.
+3. Add a drawing draft model for point/line/polygon coordinates.
+4. Connect completed drafts to Domain feature creation.


### PR DESCRIPTION
## Summary

Adds a Presentation-layer authoring state model for selecting and completing IMDF feature drafts. This gives the editor a small, testable contract before MapKit gestures, drawing coordinates, and Domain mutations are connected.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Adds `IMDFAuthoringFeature`, `IMDFAuthoringGeometry`, `IMDFAuthoringReference`, and `IMDFAuthoringContract`.
- Adds `FeatureAuthoringToolState` using `@Observable` and `@MainActor`.
- Covers every MVP IMDF feature collection with initial geometry/category/reference contracts.
- Adds Given-When-Then XCTest coverage for feature lists, contracts, completion rules, selection reset, and cancel behavior.
- Documents the authoring state boundary and next steps for progressive disclosure.

## IMDF Impact

- Establishes the first editor-side contract for all MVP IMDF feature collections.
- No GeoJSON export behavior changes.
- No Apple IMDF Validator claim in this PR.

## Architecture Notes

- `Presentation` depends on `Domain` only for `IMDFCategoryFeature` catalog mapping.
- The state model stays UI-independent and does not own MapKit camera, persistence, concrete Domain feature mutation, or inspector field editing.
- Follow-up models should keep category picker, drawing draft coordinates, and feature-specific inspector state separate.

## Verification

- [ ] `Domain`: Not run directly; no Domain source changes.
- [ ] `Data`: Not run directly; no Data source changes.
- [x] `Presentation`: `mise exec -- tuist test Presentation` passed, 8 tests.
- [ ] `DesignSystem`: Not run directly; no DesignSystem source changes.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`: Not run; no Tuist manifest changes.
- [ ] Apple IMDF Validator / preflight: Not applicable; no export/preflight behavior changes.

## Screenshots Or Recording

Not applicable; no UI changes.

## Related Issues

Closes #31

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
