### PR TITLE
feat: add editor shell foundation

### DIFF
--- a/IMDFlex/Projects/DesignSystem/Sources/Components/IMDFInspectorSection.swift
+++ b/IMDFlex/Projects/DesignSystem/Sources/Components/IMDFInspectorSection.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+
+public struct IMDFInspectorSection<Content: View>: View {
+    private let title: String
+    private let content: Content
+
+    public init(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.content = content()
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: IMDFSpacing.md) {
+            Text(title)
+                .font(IMDFFont.panelTitle)
+                .foregroundStyle(.primary)
+
+            VStack(spacing: IMDFSpacing.sm) {
+                content
+            }
+        }
+    }
+}
+
+public struct IMDFInspectorRow<Trailing: View>: View {
+    private let title: String
+    private let systemImage: String?
+    private let trailing: Trailing
+
+    public init(
+        title: String,
+        systemImage: String? = nil,
+        @ViewBuilder trailing: () -> Trailing
+    ) {
+        self.title = title
+        self.systemImage = systemImage
+        self.trailing = trailing()
+    }
+
+    public var body: some View {
+        HStack(spacing: IMDFSpacing.sm) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .font(.system(size: IMDFIconSize.sm, weight: .semibold))
+                    .frame(width: IMDFIconSize.md, height: IMDFIconSize.md)
+                    .foregroundStyle(.secondary)
+            }
+
+            Text(title)
+                .font(IMDFFont.inspectorLabel)
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: IMDFSpacing.md)
+
+            trailing
+                .font(IMDFFont.inspectorValue)
+        }
+        .frame(minHeight: 32)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+public extension IMDFInspectorRow where Trailing == Text {
+    init(
+        title: String,
+        value: String,
+        systemImage: String? = nil
+    ) {
+        self.init(title: title, systemImage: systemImage) {
+            Text(value)
+        }
+    }
+}
+
+#Preview("Inspector Section") {
+    IMDFPanel(role: .inspector) {
+        IMDFInspectorSection(title: "Authoring") {
+            IMDFInspectorRow(title: "Feature", value: "Unit", systemImage: "square.split.2x2")
+            IMDFInspectorRow(title: "Geometry", value: "Polygon", systemImage: "skew")
+            IMDFInspectorRow(title: "Ready") {
+                IMDFStatusBadge("Blocked", systemImage: "xmark.circle", role: .warning)
+            }
+        }
+    }
+    .padding()
+}

--- a/IMDFlex/Projects/DesignSystem/Sources/Components/IMDFSelectionButton.swift
+++ b/IMDFlex/Projects/DesignSystem/Sources/Components/IMDFSelectionButton.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+public struct IMDFSelectionButton: View {
+    private let title: String
+    private let subtitle: String?
+    private let systemImage: String?
+    private let isSelected: Bool
+    private let action: () -> Void
+
+    public init(
+        title: String,
+        subtitle: String? = nil,
+        systemImage: String? = nil,
+        isSelected: Bool = false,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.subtitle = subtitle
+        self.systemImage = systemImage
+        self.isSelected = isSelected
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            HStack(spacing: IMDFSpacing.sm) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.system(size: IMDFIconSize.sm, weight: .semibold))
+                        .frame(width: IMDFIconSize.lg, height: IMDFIconSize.lg)
+                }
+
+                VStack(alignment: .leading, spacing: IMDFSpacing.xxs) {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .lineLimit(1)
+
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(isSelected ? .white.opacity(0.82) : .secondary)
+                            .lineLimit(1)
+                    }
+                }
+
+                Spacer(minLength: IMDFSpacing.sm)
+
+                if isSelected {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: IMDFIconSize.sm, weight: .bold))
+                }
+            }
+            .frame(minHeight: 44)
+            .padding(.horizontal, IMDFSpacing.md)
+            .padding(.vertical, IMDFSpacing.sm)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .background(isSelected ? IMDFColor.selection : Color.primary.opacity(0.06))
+        .foregroundStyle(isSelected ? .white : .primary)
+        .overlay {
+            RoundedRectangle(cornerRadius: IMDFRadius.lg, style: .continuous)
+                .stroke(isSelected ? IMDFColor.selection : IMDFColor.separator, lineWidth: 1)
+        }
+        .clipShape(.rect(cornerRadius: IMDFRadius.lg, style: .continuous))
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}
+
+#Preview("Selection Buttons") {
+    VStack(spacing: IMDFSpacing.sm) {
+        IMDFSelectionButton(
+            title: "Unit",
+            subtitle: "Polygon",
+            systemImage: "square.split.2x2",
+            isSelected: true
+        ) {}
+
+        IMDFSelectionButton(
+            title: "Opening",
+            subtitle: "Line",
+            systemImage: "door.left.hand.open"
+        ) {}
+    }
+    .padding()
+}

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/FeatureAuthoringToolState.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/FeatureAuthoringToolState.swift
@@ -195,6 +195,18 @@ public final class FeatureAuthoringToolState {
         hasEnoughGeometry && hasRequiredCategory && hasRequiredReferences
     }
 
+    public var remainingPointCount: Int {
+        max(0, contract.geometry.minimumPointCount - draftedPointCount)
+    }
+
+    public var isCategorySatisfied: Bool {
+        hasRequiredCategory
+    }
+
+    public var missingReferences: [IMDFAuthoringReference] {
+        contract.requiredReferences.filter { !satisfiedReferences.contains($0) }
+    }
+
     public func selectFeature(_ feature: IMDFAuthoringFeature) {
         selectedFeature = feature
         resetDraft()
@@ -218,6 +230,10 @@ public final class FeatureAuthoringToolState {
 
     public func clearReference(_ reference: IMDFAuthoringReference) {
         satisfiedReferences.remove(reference)
+    }
+
+    public func satisfyRequiredReferences() {
+        satisfiedReferences.formUnion(contract.requiredReferences)
     }
 
     public func cancel() {

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorView.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorView.swift
@@ -1,94 +1,269 @@
-import SwiftUI
-import MapKit
-import Domain
 import DesignSystem
+import Domain
+import MapKit
+import SwiftUI
 
 public struct MapEditorView: View {
     let project: IMDFProject
-    
+
     @State private var cameraPosition: MapCameraPosition = .automatic
-    @State private var selectedTool: EditorTool = .select
-    
+    @State private var authoringState = FeatureAuthoringToolState()
+
     public init(project: IMDFProject) {
         self.project = project
     }
-    
+
     public var body: some View {
         ZStack {
-            // 지도 영역
-            Map(position: $cameraPosition) {
-                // 추후 IMDF 요소들 렌더링
+            Map(position: $cameraPosition)
+                .mapStyle(.standard)
+                .ignoresSafeArea(edges: .bottom)
+
+            VStack(spacing: IMDFSpacing.md) {
+                HStack(alignment: .top, spacing: IMDFSpacing.md) {
+                    Spacer(minLength: 0)
+
+                    AuthoringInspector(state: authoringState)
+                        .frame(width: 300)
+                }
+
+                Spacer(minLength: 0)
+
+                AuthoringFeatureToolbar(state: authoringState)
             }
-            .mapStyle(.standard)
-            .ignoresSafeArea(edges: .bottom)
-            
-            // 도구 팔레트
-            VStack {
-                Spacer()
-                EditorToolbar(selectedTool: $selectedTool)
-                    .padding()
-            }
+            .padding(IMDFSpacing.lg)
         }
         .navigationTitle(project.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
                 Menu {
-                    Button("내보내기", systemImage: "square.and.arrow.up") {
-                        // Export action
-                    }
-                    Button("설정", systemImage: "gear") {
-                        // Settings action
-                    }
+                    Button("Export", systemImage: "square.and.arrow.up") {}
+                    Button("Settings", systemImage: "gear") {}
                 } label: {
                     Image(systemName: "ellipsis.circle")
                 }
+                .accessibilityLabel("Editor actions")
             }
         }
     }
 }
 
-// MARK: - Editor Tools
+private struct AuthoringFeatureToolbar: View {
+    let state: FeatureAuthoringToolState
 
-enum EditorTool: String, CaseIterable {
-    case select = "arrow.up.left.and.arrow.down.right"
-    case draw = "pencil"
-    case unit = "square.split.2x2"
-    case opening = "door.left.hand.open"
-    case amenity = "mappin"
-    
+    var body: some View {
+        IMDFPanel(role: .floating) {
+            ScrollView(.horizontal) {
+                HStack(spacing: IMDFSpacing.sm) {
+                    ForEach(IMDFAuthoringFeature.allCases) { feature in
+                        IMDFToolButton(
+                            title: feature.title,
+                            systemImage: feature.systemImage,
+                            isSelected: state.selectedFeature == feature
+                        ) {
+                            state.selectFeature(feature)
+                        }
+                    }
+                }
+            }
+            .scrollIndicators(.hidden)
+        }
+    }
+}
+
+private struct AuthoringInspector: View {
+    let state: FeatureAuthoringToolState
+
+    var body: some View {
+        IMDFPanel(role: .inspector) {
+            VStack(alignment: .leading, spacing: IMDFSpacing.lg) {
+                IMDFInspectorSection(title: state.selectedFeature.title) {
+                    IMDFInspectorRow(
+                        title: "Geometry",
+                        value: state.contract.geometry.title,
+                        systemImage: state.contract.geometry.systemImage
+                    )
+
+                    IMDFInspectorRow(title: "Draft points", systemImage: "point.3.connected.trianglepath.dotted") {
+                        Text("\(state.draftedPointCount)/\(state.contract.geometry.minimumPointCount)")
+                    }
+
+                    IMDFInspectorRow(title: "Status", systemImage: state.canFinish ? "checkmark.circle" : "clock") {
+                        IMDFStatusBadge(
+                            state.canFinish ? "Ready" : "Draft",
+                            systemImage: state.canFinish ? "checkmark.circle" : "clock",
+                            role: state.canFinish ? .success : .warning
+                        )
+                    }
+                }
+
+                RequirementSection(state: state)
+                DraftControls(state: state)
+            }
+        }
+    }
+}
+
+private struct RequirementSection: View {
+    let state: FeatureAuthoringToolState
+
+    var body: some View {
+        IMDFInspectorSection(title: "Requirements") {
+            if state.contract.requiresCategory {
+                Button {
+                    state.setCategorySelected(!state.hasSelectedCategory)
+                } label: {
+                    requirementRow(
+                        title: "Category",
+                        value: state.hasSelectedCategory ? "Selected" : "Required",
+                        isReady: state.hasSelectedCategory
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+
+            if state.contract.requiredReferences.isEmpty {
+                requirementRow(title: "References", value: "None", isReady: true)
+            } else {
+                Button {
+                    state.satisfyRequiredReferences()
+                } label: {
+                    requirementRow(
+                        title: "References",
+                        value: state.missingReferences.isEmpty ? "Linked" : state.missingReferences.map(\.title).joined(separator: ", "),
+                        isReady: state.missingReferences.isEmpty
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+
+    private func requirementRow(title: String, value: String, isReady: Bool) -> some View {
+        HStack(spacing: IMDFSpacing.sm) {
+            Image(systemName: isReady ? "checkmark.circle.fill" : "circle")
+                .font(.system(size: IMDFIconSize.sm, weight: .semibold))
+                .foregroundStyle(isReady ? IMDFColor.success : .secondary)
+
+            Text(title)
+                .font(IMDFFont.inspectorLabel)
+                .foregroundStyle(.secondary)
+
+            Spacer(minLength: IMDFSpacing.md)
+
+            Text(value)
+                .font(IMDFFont.inspectorValue)
+                .lineLimit(1)
+        }
+        .frame(minHeight: 32)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct DraftControls: View {
+    let state: FeatureAuthoringToolState
+
+    var body: some View {
+        HStack(spacing: IMDFSpacing.sm) {
+            IMDFToolButton(title: "Add point", systemImage: "plus") {
+                state.addDraftPoint()
+            }
+            .disabled(state.contract.geometry == .form)
+
+            IMDFToolButton(title: "Remove point", systemImage: "minus") {
+                state.removeLastDraftPoint()
+            }
+            .disabled(state.draftedPointCount == 0)
+
+            IMDFToolButton(title: "Cancel draft", systemImage: "xmark") {
+                state.cancel()
+            }
+
+            IMDFToolButton(
+                title: "Finish draft",
+                systemImage: "checkmark",
+                isSelected: state.canFinish,
+                role: .primary
+            ) {}
+            .disabled(!state.canFinish)
+        }
+    }
+}
+
+private extension IMDFAuthoringFeature {
     var title: String {
         switch self {
-        case .select: "선택"
-        case .draw: "그리기"
-        case .unit: "공간"
-        case .opening: "출입구"
-        case .amenity: "편의시설"
+        case .address: "Address"
+        case .venue: "Venue"
+        case .building: "Building"
+        case .footprint: "Footprint"
+        case .level: "Level"
+        case .unit: "Unit"
+        case .opening: "Opening"
+        case .amenity: "Amenity"
+        case .anchor: "Anchor"
+        case .occupant: "Occupant"
+        case .detail: "Detail"
+        case .fixture: "Fixture"
+        case .geofence: "Geofence"
+        case .kiosk: "Kiosk"
+        case .relationship: "Relationship"
+        case .section: "Section"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .address: "mappin.and.ellipse"
+        case .venue: "map"
+        case .building: "building.2"
+        case .footprint: "skew"
+        case .level: "square.stack.3d.up"
+        case .unit: "square.split.2x2"
+        case .opening: "door.left.hand.open"
+        case .amenity: "fork.knife"
+        case .anchor: "pin"
+        case .occupant: "person.crop.square"
+        case .detail: "line.diagonal"
+        case .fixture: "table.furniture"
+        case .geofence: "location.viewfinder"
+        case .kiosk: "display"
+        case .relationship: "point.3.connected.trianglepath.dotted"
+        case .section: "rectangle.3.group"
         }
     }
 }
 
-struct EditorToolbar: View {
-    @Binding var selectedTool: EditorTool
-    
-    var body: some View {
-        HStack(spacing: 12) {
-            ForEach(EditorTool.allCases, id: \.self) { tool in
-                Button {
-                    selectedTool = tool
-                } label: {
-                    Image(systemName: tool.rawValue)
-                        .font(.title2)
-                        .frame(width: 44, height: 44)
-                        .background(selectedTool == tool ? Color.imdfPrimary : Color.imdfBackground)
-                        .foregroundStyle(selectedTool == tool ? .white : .primary)
-                        .clipShape(RoundedRectangle(cornerRadius: 8))
-                }
-                .accessibilityLabel(tool.title)
-            }
+private extension IMDFAuthoringGeometry {
+    var title: String {
+        switch self {
+        case .point: "Point"
+        case .line: "Line"
+        case .polygon: "Polygon"
+        case .form: "Form"
         }
-        .padding(8)
-        .background(.ultraThinMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
+    }
+
+    var systemImage: String {
+        switch self {
+        case .point: "smallcircle.filled.circle"
+        case .line: "line.diagonal"
+        case .polygon: "skew"
+        case .form: "list.bullet.rectangle"
+        }
+    }
+}
+
+private extension IMDFAuthoringReference {
+    var title: String {
+        switch self {
+        case .building: "Building"
+        case .level: "Level"
+        case .unit: "Unit"
+        case .anchor: "Anchor"
+        case .levelOrBuilding: "Level or building"
+        case .relationshipEndpoints: "Endpoints"
+        }
     }
 }

--- a/IMDFlex/Projects/Presentation/Tests/FeatureAuthoringToolStateTests.swift
+++ b/IMDFlex/Projects/Presentation/Tests/FeatureAuthoringToolStateTests.swift
@@ -102,6 +102,7 @@ final class FeatureAuthoringToolStateTests: XCTestCase {
 
         // Then
         XCTAssertFalse(sut.canFinish)
+        XCTAssertEqual(sut.remainingPointCount, 1)
     }
 
     func test_whenPolygonFeatureHasRequiredCategoryReferenceAndPoints_thenStateCanFinish() {
@@ -130,6 +131,40 @@ final class FeatureAuthoringToolStateTests: XCTestCase {
         // Then
         XCTAssertTrue(sut.canFinish)
         XCTAssertEqual(sut.draftedPointCount, 0)
+        XCTAssertEqual(sut.remainingPointCount, 0)
+    }
+
+    func test_whenFeatureRequiresReferences_thenMissingReferencesExposeOnlyUnsatisfiedReferences() {
+        // Given
+        let sut = makeSUT(selectedFeature: .footprint)
+
+        // When
+        let missingReferences = sut.missingReferences
+
+        // Then
+        XCTAssertEqual(missingReferences, [.building])
+    }
+
+    func test_whenRequiredReferencesAreSatisfied_thenMissingReferencesBecomeEmpty() {
+        // Given
+        let sut = makeSUT(selectedFeature: .relationship)
+
+        // When
+        sut.satisfyRequiredReferences()
+
+        // Then
+        XCTAssertTrue(sut.missingReferences.isEmpty)
+    }
+
+    func test_whenCategoryIsRequiredButNotSelected_thenCategoryIsNotSatisfied() {
+        // Given
+        let sut = makeSUT(selectedFeature: .amenity)
+
+        // When
+        let isCategorySatisfied = sut.isCategorySatisfied
+
+        // Then
+        XCTAssertFalse(isCategorySatisfied)
     }
 
     func test_whenFeatureSelectionChanges_thenDraftStateIsReset() {

--- a/docs/editor-shell-foundation.md
+++ b/docs/editor-shell-foundation.md
@@ -1,0 +1,84 @@
+# Editor Shell Foundation
+
+This document records the first editor shell boundary for IMDFlex.
+
+## Goal
+
+The editor shell connects the Presentation-layer IMDF authoring state to visible editor controls without committing to MapKit coordinate capture, Domain feature mutation, persistence, or GeoJSON export yet.
+
+This keeps the workflow map-first while letting the UI progressively disclose only what the current authoring feature needs:
+
+- selected IMDF feature
+- geometry mode
+- drafted point count
+- category readiness
+- reference readiness
+- draft completion readiness
+
+## Component Boundary
+
+### DesignSystem
+
+DesignSystem should provide small, reusable primitives that do not know about IMDF feature semantics.
+
+Current editor primitives:
+
+- `IMDFToolButton`: icon-only command button for compact map tools.
+- `IMDFPanel`: material-backed floating, inspector, and status surfaces.
+- `IMDFStatusBadge`: compact status display.
+- `IMDFSelectionButton`: selectable row-like control for feature or mode lists.
+- `IMDFInspectorSection`: titled inspector grouping.
+- `IMDFInspectorRow`: compact key/value inspector row.
+
+These components should stay generic. They should not import `Domain` or `Presentation`, and they should not know about categories, levels, units, or GeoJSON.
+
+### Presentation
+
+Presentation owns editor-specific composition:
+
+- `MapEditorView`
+- `FeatureAuthoringToolState`
+- feature display names and SF Symbol choices
+- draft controls that call authoring state intents
+- category/reference readiness placeholders
+
+Presentation can depend on `Domain` and `DesignSystem`, but it should keep Domain mutations behind future editor use cases or coordinators.
+
+## Astryx Reference
+
+Astryx Components is used as a taxonomy reference, not as a visual copy target.
+
+Useful categories for IMDFlex:
+
+- Action: toolbar, icon button, segmented/selection controls.
+- Container: panel, collapsible inspector section.
+- Data Input: field, selector, typeahead, slider.
+- Feedback & Status: badge, status dot, banner.
+- Layout: app shell, divider, section, resize handle.
+- Overlay: popover, tooltip, command palette.
+
+IMDFlex should translate these ideas into native SwiftUI controls that follow Apple HIG and fit iPad/Mac map editing.
+
+## Progressive Disclosure Rules
+
+- Keep DesignSystem controls small and reusable.
+- Compose inspector headers, footers, and actions in Presentation.
+- Do not create one large editor component that owns all state.
+- Add category picker, reference picker, drawing coordinates, and inspector forms as adjacent models.
+- Avoid hiding important workflow state in SwiftUI view bodies when it can be represented by testable state or coordinator APIs.
+
+## Deferred Work
+
+The current shell intentionally does not implement:
+
+- address search
+- map locking
+- level selection
+- floor-plan overlay alignment
+- coordinate storage
+- GeoJSON conversion
+- Domain feature creation
+- `imdf.zip` export
+- Apple IMDF Validator execution
+
+Those should be added as focused follow-up PRs.


### PR DESCRIPTION
## Summary

Adds the first editor shell foundation for IMDFlex by connecting the authoring state model to visible map editor controls, while shaping small DesignSystem primitives from real editor usage.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added `IMDFSelectionButton`, `IMDFInspectorSection`, and `IMDFInspectorRow` as small DesignSystem primitives.
- Replaced the temporary map toolbar with an authoring-state-driven editor shell.
- Exposed feature selection, geometry, draft point count, category/reference readiness, and finish readiness.
- Added small derived authoring-state APIs for remaining point count, category readiness, missing references, and satisfying required references.
- Expanded Presentation tests from 8 to 11 cases.
- Documented editor shell boundaries and Astryx usage as a taxonomy reference.

## IMDF Impact

- Presentation-only IMDF authoring workflow impact.
- No GeoJSON schema/export changes.
- No Apple IMDF Validator claim in this PR.

## Architecture Notes

- `DesignSystem` remains generic and does not import `Domain` or `Presentation`.
- `Presentation` composes IMDF-specific editor behavior using public `Domain` and `DesignSystem` interfaces.
- MapKit coordinate storage, Domain feature mutation, persistence, and export remain deferred.

## Verification

- [ ] `Domain`: Not run directly; no Domain source changes.
- [ ] `Data`: Not run directly; no Data source changes.
- [x] `Presentation`: `mise exec -- tuist test Presentation` passed, 11 tests.
- [x] `DesignSystem`: `mise exec -- tuist build DesignSystem` passed.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`: Not run; no Tuist manifest changes.
- [ ] Apple IMDF Validator / preflight: Not applicable; no export/preflight behavior changes.

## Screenshots Or Recording

Not captured in this PR. The change is a first SwiftUI shell foundation and was verified by module build/tests.

## Related Issues

Closes #33

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
