### PR TITLE
feat: add drawing draft state

### DIFF
--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/DrawingDraftState.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/DrawingDraftState.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Observation
+
+public struct IMDFDraftCoordinate: Codable, Equatable, Hashable, Sendable {
+    public let longitude: Double
+    public let latitude: Double
+
+    public init(longitude: Double, latitude: Double) {
+        self.longitude = longitude
+        self.latitude = latitude
+    }
+
+    public var geoJSONPosition: [Double] {
+        [longitude, latitude]
+    }
+}
+
+public struct IMDFDrawingDraftResult: Equatable, Sendable {
+    public let geometry: IMDFAuthoringGeometry
+    public let coordinates: [IMDFDraftCoordinate]
+
+    public init(
+        geometry: IMDFAuthoringGeometry,
+        coordinates: [IMDFDraftCoordinate]
+    ) {
+        self.geometry = geometry
+        self.coordinates = coordinates
+    }
+}
+
+@MainActor
+@Observable
+public final class DrawingDraftState {
+    public private(set) var geometry: IMDFAuthoringGeometry
+    public private(set) var coordinates: [IMDFDraftCoordinate]
+
+    public init(
+        geometry: IMDFAuthoringGeometry,
+        coordinates: [IMDFDraftCoordinate] = []
+    ) {
+        self.geometry = geometry
+        self.coordinates = coordinates
+    }
+
+    public var pointCount: Int {
+        coordinates.count
+    }
+
+    public var minimumPointCount: Int {
+        geometry.minimumPointCount
+    }
+
+    public var remainingPointCount: Int {
+        max(0, minimumPointCount - pointCount)
+    }
+
+    public var canFinish: Bool {
+        pointCount >= minimumPointCount
+    }
+
+    public func setGeometry(_ geometry: IMDFAuthoringGeometry) {
+        self.geometry = geometry
+        clear()
+    }
+
+    public func append(_ coordinate: IMDFDraftCoordinate) {
+        guard geometry != .form else { return }
+        coordinates.append(coordinate)
+    }
+
+    public func removeLastCoordinate() {
+        guard !coordinates.isEmpty else { return }
+        coordinates.removeLast()
+    }
+
+    public func clear() {
+        coordinates = []
+    }
+
+    public func finish() -> IMDFDrawingDraftResult? {
+        guard canFinish else { return nil }
+
+        return IMDFDrawingDraftResult(
+            geometry: geometry,
+            coordinates: coordinates
+        )
+    }
+}

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/FeatureAuthoringToolState.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/Authoring/FeatureAuthoringToolState.swift
@@ -171,18 +171,18 @@ public struct IMDFAuthoringContract: Codable, Equatable, Sendable {
 @Observable
 public final class FeatureAuthoringToolState {
     public private(set) var selectedFeature: IMDFAuthoringFeature
-    public private(set) var draftedPointCount: Int
+    public private(set) var drawingDraft: DrawingDraftState
     public private(set) var hasSelectedCategory: Bool
     public private(set) var satisfiedReferences: Set<IMDFAuthoringReference>
 
     public init(
         selectedFeature: IMDFAuthoringFeature = .unit,
-        draftedPointCount: Int = 0,
+        drawingDraft: DrawingDraftState? = nil,
         hasSelectedCategory: Bool = false,
         satisfiedReferences: Set<IMDFAuthoringReference> = []
     ) {
         self.selectedFeature = selectedFeature
-        self.draftedPointCount = draftedPointCount
+        self.drawingDraft = drawingDraft ?? DrawingDraftState(geometry: selectedFeature.contract.geometry)
         self.hasSelectedCategory = hasSelectedCategory
         self.satisfiedReferences = satisfiedReferences
     }
@@ -196,7 +196,15 @@ public final class FeatureAuthoringToolState {
     }
 
     public var remainingPointCount: Int {
-        max(0, contract.geometry.minimumPointCount - draftedPointCount)
+        drawingDraft.remainingPointCount
+    }
+
+    public var draftedPointCount: Int {
+        drawingDraft.pointCount
+    }
+
+    public var draftedCoordinates: [IMDFDraftCoordinate] {
+        drawingDraft.coordinates
     }
 
     public var isCategorySatisfied: Bool {
@@ -213,11 +221,15 @@ public final class FeatureAuthoringToolState {
     }
 
     public func addDraftPoint() {
-        draftedPointCount += 1
+        appendDraftCoordinate(.placeholder)
+    }
+
+    public func appendDraftCoordinate(_ coordinate: IMDFDraftCoordinate) {
+        drawingDraft.append(coordinate)
     }
 
     public func removeLastDraftPoint() {
-        draftedPointCount = max(0, draftedPointCount - 1)
+        drawingDraft.removeLastCoordinate()
     }
 
     public func setCategorySelected(_ isSelected: Bool) {
@@ -240,8 +252,14 @@ public final class FeatureAuthoringToolState {
         resetDraft()
     }
 
+    public func finishDrawingDraft() -> IMDFDrawingDraftResult? {
+        guard canFinish else { return nil }
+
+        return drawingDraft.finish()
+    }
+
     private var hasEnoughGeometry: Bool {
-        draftedPointCount >= contract.geometry.minimumPointCount
+        drawingDraft.canFinish
     }
 
     private var hasRequiredCategory: Bool {
@@ -253,8 +271,12 @@ public final class FeatureAuthoringToolState {
     }
 
     private func resetDraft() {
-        draftedPointCount = 0
+        drawingDraft.setGeometry(contract.geometry)
         hasSelectedCategory = false
         satisfiedReferences = []
     }
+}
+
+private extension IMDFDraftCoordinate {
+    static let placeholder = IMDFDraftCoordinate(longitude: 0, latitude: 0)
 }

--- a/IMDFlex/Projects/Presentation/Tests/DrawingDraftStateTests.swift
+++ b/IMDFlex/Projects/Presentation/Tests/DrawingDraftStateTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import Presentation
+
+@MainActor
+final class DrawingDraftStateTests: XCTestCase {
+    func test_whenCoordinateIsCreated_thenGeoJSONPositionUsesLongitudeLatitudeOrder() {
+        // Given
+        let coordinate = IMDFDraftCoordinate(longitude: 127.0276, latitude: 37.4979)
+
+        // When
+        let position = coordinate.geoJSONPosition
+
+        // Then
+        XCTAssertEqual(position, [127.0276, 37.4979])
+    }
+
+    func test_whenPointGeometryHasOneCoordinate_thenDraftCanFinish() {
+        // Given
+        let sut = makeSUT(geometry: .point)
+
+        // When
+        sut.append(.fixture())
+
+        // Then
+        XCTAssertTrue(sut.canFinish)
+        XCTAssertEqual(sut.remainingPointCount, 0)
+    }
+
+    func test_whenLineGeometryHasOneCoordinate_thenDraftCannotFinish() {
+        // Given
+        let sut = makeSUT(geometry: .line)
+
+        // When
+        sut.append(.fixture())
+
+        // Then
+        XCTAssertFalse(sut.canFinish)
+        XCTAssertEqual(sut.remainingPointCount, 1)
+    }
+
+    func test_whenPolygonGeometryHasThreeCoordinates_thenDraftCanFinish() {
+        // Given
+        let sut = makeSUT(geometry: .polygon)
+
+        // When
+        sut.append(.fixture(longitude: 127.0, latitude: 37.0))
+        sut.append(.fixture(longitude: 127.1, latitude: 37.0))
+        sut.append(.fixture(longitude: 127.1, latitude: 37.1))
+
+        // Then
+        XCTAssertTrue(sut.canFinish)
+        XCTAssertEqual(sut.pointCount, 3)
+    }
+
+    func test_whenFormGeometryReceivesCoordinate_thenCoordinateIsIgnoredAndCanFinish() {
+        // Given
+        let sut = makeSUT(geometry: .form)
+
+        // When
+        sut.append(.fixture())
+
+        // Then
+        XCTAssertTrue(sut.canFinish)
+        XCTAssertTrue(sut.coordinates.isEmpty)
+    }
+
+    func test_whenLastCoordinateIsRemoved_thenPointCountDecreases() {
+        // Given
+        let sut = makeSUT(geometry: .line)
+        sut.append(.fixture(longitude: 127.0, latitude: 37.0))
+        sut.append(.fixture(longitude: 127.1, latitude: 37.1))
+
+        // When
+        sut.removeLastCoordinate()
+
+        // Then
+        XCTAssertEqual(sut.coordinates, [.fixture(longitude: 127.0, latitude: 37.0)])
+    }
+
+    func test_whenDraftIsCleared_thenCoordinatesAreRemoved() {
+        // Given
+        let sut = makeSUT(geometry: .polygon)
+        sut.append(.fixture())
+        sut.append(.fixture(longitude: 127.1, latitude: 37.1))
+
+        // When
+        sut.clear()
+
+        // Then
+        XCTAssertTrue(sut.coordinates.isEmpty)
+        XCTAssertEqual(sut.remainingPointCount, 3)
+    }
+
+    func test_whenGeometryChanges_thenDraftIsClearedAndMinimumPointCountChanges() {
+        // Given
+        let sut = makeSUT(geometry: .polygon)
+        sut.append(.fixture())
+        sut.append(.fixture(longitude: 127.1, latitude: 37.1))
+
+        // When
+        sut.setGeometry(.line)
+
+        // Then
+        XCTAssertEqual(sut.geometry, .line)
+        XCTAssertTrue(sut.coordinates.isEmpty)
+        XCTAssertEqual(sut.minimumPointCount, 2)
+    }
+
+    func test_whenDraftCannotFinish_thenFinishReturnsNil() {
+        // Given
+        let sut = makeSUT(geometry: .polygon)
+        sut.append(.fixture())
+        sut.append(.fixture(longitude: 127.1, latitude: 37.1))
+
+        // When
+        let result = sut.finish()
+
+        // Then
+        XCTAssertNil(result)
+    }
+
+    func test_whenDraftCanFinish_thenFinishReturnsGeometryAndCoordinates() throws {
+        // Given
+        let sut = makeSUT(geometry: .line)
+        let first = IMDFDraftCoordinate.fixture(longitude: 127.0, latitude: 37.0)
+        let second = IMDFDraftCoordinate.fixture(longitude: 127.1, latitude: 37.1)
+        sut.append(first)
+        sut.append(second)
+
+        // When
+        let result = try XCTUnwrap(sut.finish())
+
+        // Then
+        XCTAssertEqual(result.geometry, .line)
+        XCTAssertEqual(result.coordinates, [first, second])
+    }
+
+    private func makeSUT(geometry: IMDFAuthoringGeometry) -> DrawingDraftState {
+        DrawingDraftState(geometry: geometry)
+    }
+}
+
+private extension IMDFDraftCoordinate {
+    static func fixture(
+        longitude: Double = 127.0276,
+        latitude: Double = 37.4979
+    ) -> Self {
+        .init(longitude: longitude, latitude: latitude)
+    }
+}

--- a/IMDFlex/Projects/Presentation/Tests/FeatureAuthoringToolStateTests.swift
+++ b/IMDFlex/Projects/Presentation/Tests/FeatureAuthoringToolStateTests.swift
@@ -112,12 +112,13 @@ final class FeatureAuthoringToolStateTests: XCTestCase {
         // When
         sut.setCategorySelected(true)
         sut.satisfyReference(.level)
-        sut.addDraftPoint()
-        sut.addDraftPoint()
-        sut.addDraftPoint()
+        sut.appendDraftCoordinate(.fixture(longitude: 127.0, latitude: 37.0))
+        sut.appendDraftCoordinate(.fixture(longitude: 127.1, latitude: 37.0))
+        sut.appendDraftCoordinate(.fixture(longitude: 127.1, latitude: 37.1))
 
         // Then
         XCTAssertTrue(sut.canFinish)
+        XCTAssertEqual(sut.draftedCoordinates.map(\.geoJSONPosition), [[127.0, 37.0], [127.1, 37.0], [127.1, 37.1]])
     }
 
     func test_whenFormFeatureHasRequiredCategoryAndReference_thenStateCanFinishWithoutPoints() {
@@ -172,8 +173,8 @@ final class FeatureAuthoringToolStateTests: XCTestCase {
         let sut = makeSUT(selectedFeature: .unit)
         sut.setCategorySelected(true)
         sut.satisfyReference(.level)
-        sut.addDraftPoint()
-        sut.addDraftPoint()
+        sut.appendDraftCoordinate(.fixture(longitude: 127.0, latitude: 37.0))
+        sut.appendDraftCoordinate(.fixture(longitude: 127.1, latitude: 37.0))
 
         // When
         sut.selectFeature(.amenity)
@@ -181,6 +182,7 @@ final class FeatureAuthoringToolStateTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.selectedFeature, .amenity)
         XCTAssertEqual(sut.draftedPointCount, 0)
+        XCTAssertEqual(sut.drawingDraft.geometry, .point)
         XCTAssertFalse(sut.hasSelectedCategory)
         XCTAssertTrue(sut.satisfiedReferences.isEmpty)
     }
@@ -190,7 +192,7 @@ final class FeatureAuthoringToolStateTests: XCTestCase {
         let sut = makeSUT(selectedFeature: .opening)
         sut.setCategorySelected(true)
         sut.satisfyReference(.level)
-        sut.addDraftPoint()
+        sut.appendDraftCoordinate(.fixture())
 
         // When
         sut.cancel()
@@ -198,11 +200,39 @@ final class FeatureAuthoringToolStateTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.selectedFeature, .opening)
         XCTAssertEqual(sut.draftedPointCount, 0)
+        XCTAssertEqual(sut.drawingDraft.geometry, .line)
         XCTAssertFalse(sut.hasSelectedCategory)
         XCTAssertTrue(sut.satisfiedReferences.isEmpty)
     }
 
+    func test_whenAuthoringDraftCanFinish_thenFinishDrawingDraftReturnsDraftResult() throws {
+        // Given
+        let sut = makeSUT(selectedFeature: .opening)
+        let first = IMDFDraftCoordinate.fixture(longitude: 127.0, latitude: 37.0)
+        let second = IMDFDraftCoordinate.fixture(longitude: 127.1, latitude: 37.1)
+        sut.setCategorySelected(true)
+        sut.satisfyReference(.level)
+        sut.appendDraftCoordinate(first)
+        sut.appendDraftCoordinate(second)
+
+        // When
+        let result = try XCTUnwrap(sut.finishDrawingDraft())
+
+        // Then
+        XCTAssertEqual(result.geometry, .line)
+        XCTAssertEqual(result.coordinates, [first, second])
+    }
+
     private func makeSUT(selectedFeature: IMDFAuthoringFeature = .unit) -> FeatureAuthoringToolState {
         FeatureAuthoringToolState(selectedFeature: selectedFeature)
+    }
+}
+
+private extension IMDFDraftCoordinate {
+    static func fixture(
+        longitude: Double = 127.0276,
+        latitude: Double = 37.4979
+    ) -> Self {
+        .init(longitude: longitude, latitude: latitude)
     }
 }

--- a/docs/drawing-draft-state.md
+++ b/docs/drawing-draft-state.md
@@ -1,0 +1,77 @@
+# Drawing Draft State
+
+This document records the first coordinate-based drawing draft boundary for IMDFlex.
+
+## Purpose
+
+`DrawingDraftState` represents the in-progress geometry that a user is authoring before it becomes a Domain IMDF feature.
+
+The model is intentionally Presentation-layer state:
+
+- It stores draft coordinates.
+- It validates geometry readiness.
+- It can produce a draft result.
+- It does not create Domain features.
+- It does not serialize GeoJSON.
+- It does not own MapKit gesture recognition.
+
+## Coordinate Order
+
+`IMDFDraftCoordinate` stores coordinates as:
+
+- `longitude`
+- `latitude`
+
+Its `geoJSONPosition` returns `[longitude, latitude]`.
+
+This mirrors GeoJSON position order and keeps IMDFlex from accidentally treating positions as `[latitude, longitude]` later.
+
+## Geometry Readiness
+
+The draft follows `IMDFAuthoringGeometry.minimumPointCount`:
+
+| Geometry | Minimum coordinates | Notes |
+| --- | ---: | --- |
+| `point` | 1 | A single tapped coordinate. |
+| `line` | 2 | A connected line draft. |
+| `polygon` | 3 | A polygon ring draft, not closed by this model yet. |
+| `form` | 0 | Metadata-only authoring; coordinates are ignored. |
+
+`DrawingDraftState.finish()` returns `nil` until the minimum coordinate count is satisfied.
+
+## Authoring Integration
+
+`FeatureAuthoringToolState` now owns a `DrawingDraftState`.
+
+The authoring state still owns IMDF workflow readiness:
+
+- selected feature
+- category readiness
+- required references
+- combined finish readiness
+
+The drawing draft owns only geometry readiness:
+
+- selected geometry
+- coordinate list
+- point count
+- finish result
+
+This keeps category/reference rules separate from map coordinate drafting.
+
+## Deferred Work
+
+The current draft model intentionally leaves these for follow-up PRs:
+
+- MapKit tap/drag gesture capture.
+- Snapping or grid alignment.
+- Polygon ring closing behavior.
+- Undo/redo stacks.
+- Coordinate projection or overlay transform handling.
+- Domain feature creation.
+- GeoJSON serialization.
+- Apple IMDF Validator or preflight integration.
+
+## Next Step
+
+The next natural PR is to connect MapKit tap gestures to `appendDraftCoordinate(_:)`, converting map tap locations into `IMDFDraftCoordinate` values.

--- a/docs/editor-shell-foundation.md
+++ b/docs/editor-shell-foundation.md
@@ -75,7 +75,7 @@ The current shell intentionally does not implement:
 - map locking
 - level selection
 - floor-plan overlay alignment
-- coordinate storage
+- MapKit gesture coordinate capture
 - GeoJSON conversion
 - Domain feature creation
 - `imdf.zip` export


### PR DESCRIPTION
## Summary

Adds a coordinate-based drawing draft state for point-based IMDF authoring. This replaces point-count-only drafting with explicit longitude/latitude coordinates while keeping MapKit gesture capture, Domain feature creation, and GeoJSON export deferred.

## Type

- [x] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [ ] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added `IMDFDraftCoordinate` with explicit `longitude` and `latitude` fields.
- Added `geoJSONPosition` returning `[longitude, latitude]`.
- Added `DrawingDraftState` for point, line, polygon, and form geometry readiness.
- Added `IMDFDrawingDraftResult` as the finish result boundary.
- Updated `FeatureAuthoringToolState` to own `DrawingDraftState`.
- Added tests for coordinate order, minimum point rules, reset behavior, finish behavior, and authoring integration.
- Documented the drawing draft boundary and follow-up MapKit/GeoJSON work.

## IMDF Impact

- Establishes coordinate ordering discipline for future GeoJSON export.
- Presentation-only authoring state impact.
- No GeoJSON serialization, ZIP export, or Apple IMDF Validator behavior changes.

## Architecture Notes

- `DrawingDraftState` lives in `Presentation` because it represents in-progress editor interaction state.
- The draft does not import MapKit and does not mutate Domain IMDF feature models.
- Domain authoring use cases, GeoJSON serialization, and export remain separate follow-up work.

## Verification

- [ ] `Domain`: Not run directly; no Domain source changes.
- [ ] `Data`: Not run directly; no Data source changes.
- [x] `Presentation`: `mise exec -- tuist test Presentation` passed, 22 tests.
- [ ] `DesignSystem`: Not run directly; no DesignSystem source changes.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`: Not run; no Tuist manifest changes.
- [ ] Apple IMDF Validator / preflight: Not applicable; no export/preflight behavior changes.

## Screenshots Or Recording

Not applicable; behavior is Presentation state and test coverage.

## Related Issues

Closes #35

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
