### PR TITLE
refactor: align map editor presentation with MVVM

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,9 @@ IMDFlex is an Apple IMDF authoring app for iPad and Mac. It should help users cr
 - Prefer protocol-based dependency injection for repositories, exporters, validators, and services.
 - Keep business logic testable outside SwiftUI views.
 - Place view logic in testable model/coordinator/service types rather than burying it in view bodies.
+- In Presentation, keep SwiftUI views thin. Views should read display-ready state from `@Observable` ViewModels and call ViewModel intents, not directly orchestrate editor workflow state.
+- Keep Presentation display descriptors/mappers outside SwiftUI view files when feature, geometry, reference, icon, label, status, or localization mapping is involved.
+- State types such as drawing drafts may model focused UI interaction state, but ViewModels should own cross-state orchestration and user intents.
 - Do not turn the product into only a feature-by-feature CRUD app. Keep the map-first IMDF authoring workflow central.
 
 ## Swift

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ IMDFlex is an Apple IMDF authoring app for iPad and Mac. It should help users cr
 - Keep business logic testable outside SwiftUI views.
 - Place view logic in testable model/coordinator/service types rather than burying it in view bodies.
 - In Presentation, keep SwiftUI views thin. Views should read display-ready state from `@Observable` ViewModels and call ViewModel intents, not directly orchestrate editor workflow state.
+- Prefer passing the smallest display state and intent closures into child SwiftUI views. Do not pass an entire ViewModel into a child view unless that child is itself a routed screen or owns a distinct MVVM boundary.
 - Keep Presentation display descriptors/mappers outside SwiftUI view files when feature, geometry, reference, icon, label, status, or localization mapping is involved.
 - State types such as drawing drafts may model focused UI interaction state, but ViewModels should own cross-state orchestration and user intents.
 - Do not turn the product into only a feature-by-feature CRUD app. Keep the map-first IMDF authoring workflow central.

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorDisplayDescriptor.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorDisplayDescriptor.swift
@@ -1,0 +1,129 @@
+import Foundation
+
+public struct IMDFAuthoringFeatureDisplayDescriptor: Equatable, Identifiable, Sendable {
+    public let feature: IMDFAuthoringFeature
+    public let title: String
+    public let systemImage: String
+
+    public var id: IMDFAuthoringFeature {
+        feature
+    }
+
+    public init(
+        feature: IMDFAuthoringFeature,
+        title: String,
+        systemImage: String
+    ) {
+        self.feature = feature
+        self.title = title
+        self.systemImage = systemImage
+    }
+}
+
+public struct IMDFAuthoringGeometryDisplayDescriptor: Equatable, Sendable {
+    public let geometry: IMDFAuthoringGeometry
+    public let title: String
+    public let systemImage: String
+
+    public init(
+        geometry: IMDFAuthoringGeometry,
+        title: String,
+        systemImage: String
+    ) {
+        self.geometry = geometry
+        self.title = title
+        self.systemImage = systemImage
+    }
+}
+
+public struct IMDFAuthoringReferenceDisplayDescriptor: Equatable, Sendable {
+    public let reference: IMDFAuthoringReference
+    public let title: String
+
+    public init(
+        reference: IMDFAuthoringReference,
+        title: String
+    ) {
+        self.reference = reference
+        self.title = title
+    }
+}
+
+public enum MapEditorDisplayDescriptor {
+    public static let features: [IMDFAuthoringFeatureDisplayDescriptor] = IMDFAuthoringFeature.allCases.map {
+        featureDescriptor(for: $0)
+    }
+
+    public static func featureDescriptor(
+        for feature: IMDFAuthoringFeature
+    ) -> IMDFAuthoringFeatureDisplayDescriptor {
+        switch feature {
+        case .address:
+            .init(feature: feature, title: "Address", systemImage: "mappin.and.ellipse")
+        case .venue:
+            .init(feature: feature, title: "Venue", systemImage: "map")
+        case .building:
+            .init(feature: feature, title: "Building", systemImage: "building.2")
+        case .footprint:
+            .init(feature: feature, title: "Footprint", systemImage: "skew")
+        case .level:
+            .init(feature: feature, title: "Level", systemImage: "square.stack.3d.up")
+        case .unit:
+            .init(feature: feature, title: "Unit", systemImage: "square.split.2x2")
+        case .opening:
+            .init(feature: feature, title: "Opening", systemImage: "door.left.hand.open")
+        case .amenity:
+            .init(feature: feature, title: "Amenity", systemImage: "fork.knife")
+        case .anchor:
+            .init(feature: feature, title: "Anchor", systemImage: "pin")
+        case .occupant:
+            .init(feature: feature, title: "Occupant", systemImage: "person.crop.square")
+        case .detail:
+            .init(feature: feature, title: "Detail", systemImage: "line.diagonal")
+        case .fixture:
+            .init(feature: feature, title: "Fixture", systemImage: "table.furniture")
+        case .geofence:
+            .init(feature: feature, title: "Geofence", systemImage: "location.viewfinder")
+        case .kiosk:
+            .init(feature: feature, title: "Kiosk", systemImage: "display")
+        case .relationship:
+            .init(feature: feature, title: "Relationship", systemImage: "point.3.connected.trianglepath.dotted")
+        case .section:
+            .init(feature: feature, title: "Section", systemImage: "rectangle.3.group")
+        }
+    }
+
+    public static func geometryDescriptor(
+        for geometry: IMDFAuthoringGeometry
+    ) -> IMDFAuthoringGeometryDisplayDescriptor {
+        switch geometry {
+        case .point:
+            .init(geometry: geometry, title: "Point", systemImage: "smallcircle.filled.circle")
+        case .line:
+            .init(geometry: geometry, title: "Line", systemImage: "line.diagonal")
+        case .polygon:
+            .init(geometry: geometry, title: "Polygon", systemImage: "skew")
+        case .form:
+            .init(geometry: geometry, title: "Form", systemImage: "list.bullet.rectangle")
+        }
+    }
+
+    public static func referenceDescriptor(
+        for reference: IMDFAuthoringReference
+    ) -> IMDFAuthoringReferenceDisplayDescriptor {
+        switch reference {
+        case .building:
+            .init(reference: reference, title: "Building")
+        case .level:
+            .init(reference: reference, title: "Level")
+        case .unit:
+            .init(reference: reference, title: "Unit")
+        case .anchor:
+            .init(reference: reference, title: "Anchor")
+        case .levelOrBuilding:
+            .init(reference: reference, title: "Level or building")
+        case .relationshipEndpoints:
+            .init(reference: reference, title: "Endpoints")
+        }
+    }
+}

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorView.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorView.swift
@@ -4,18 +4,17 @@ import MapKit
 import SwiftUI
 
 public struct MapEditorView: View {
-    let project: IMDFProject
-
-    @State private var cameraPosition: MapCameraPosition = .automatic
-    @State private var viewModel = MapEditorViewModel()
+    @State private var viewModel: MapEditorViewModel
 
     public init(project: IMDFProject) {
-        self.project = project
+        self._viewModel = State(initialValue: MapEditorViewModel(project: project))
     }
 
     public var body: some View {
+        @Bindable var viewModel = viewModel
+
         ZStack {
-            Map(position: $cameraPosition)
+            Map(position: $viewModel.cameraPosition)
                 .mapStyle(.standard)
                 .ignoresSafeArea(edges: .bottom)
 
@@ -23,17 +22,39 @@ public struct MapEditorView: View {
                 HStack(alignment: .top, spacing: IMDFSpacing.md) {
                     Spacer(minLength: 0)
 
-                    AuthoringInspector(viewModel: viewModel)
+                    AuthoringInspector(
+                        selectedFeature: viewModel.selectedFeatureDescriptor,
+                        geometry: viewModel.geometryDescriptor,
+                        draftProgressText: viewModel.draftProgressText,
+                        draftStatus: viewModel.draftStatus,
+                        categoryRequirement: viewModel.categoryRequirement,
+                        referenceRequirement: viewModel.referenceRequirement,
+                        canAddDraftPoint: viewModel.canAddDraftPoint,
+                        canRemoveDraftPoint: viewModel.canRemoveDraftPoint,
+                        canFinishDraft: viewModel.canFinishDraft,
+                        onToggleCategorySelection: viewModel.toggleCategorySelection,
+                        onSatisfyRequiredReferences: viewModel.satisfyRequiredReferences,
+                        onAddDraftPoint: viewModel.addDraftPoint,
+                        onRemoveLastDraftPoint: viewModel.removeLastDraftPoint,
+                        onCancelDraft: viewModel.cancelDraft,
+                        onFinishDraft: {
+                            viewModel.finishDraft()
+                        }
+                    )
                         .frame(width: 300)
                 }
 
                 Spacer(minLength: 0)
 
-                AuthoringFeatureToolbar(viewModel: viewModel)
+                AuthoringFeatureToolbar(
+                    featureTools: viewModel.featureTools,
+                    selectedFeature: viewModel.selectedFeature,
+                    onSelectFeature: viewModel.selectFeature
+                )
             }
             .padding(IMDFSpacing.lg)
         }
-        .navigationTitle(project.name)
+        .navigationTitle(viewModel.navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .primaryAction) {
@@ -50,19 +71,21 @@ public struct MapEditorView: View {
 }
 
 private struct AuthoringFeatureToolbar: View {
-    let viewModel: MapEditorViewModel
+    let featureTools: [IMDFAuthoringFeatureDisplayDescriptor]
+    let selectedFeature: IMDFAuthoringFeature
+    let onSelectFeature: (IMDFAuthoringFeature) -> Void
 
     var body: some View {
         IMDFPanel(role: .floating) {
             ScrollView(.horizontal) {
                 HStack(spacing: IMDFSpacing.sm) {
-                    ForEach(viewModel.featureTools) { feature in
+                    ForEach(featureTools) { feature in
                         IMDFToolButton(
                             title: feature.title,
                             systemImage: feature.systemImage,
-                            isSelected: viewModel.selectedFeature == feature.feature
+                            isSelected: selectedFeature == feature.feature
                         ) {
-                            viewModel.selectFeature(feature.feature)
+                            onSelectFeature(feature.feature)
                         }
                     }
                 }
@@ -73,46 +96,76 @@ private struct AuthoringFeatureToolbar: View {
 }
 
 private struct AuthoringInspector: View {
-    let viewModel: MapEditorViewModel
+    let selectedFeature: IMDFAuthoringFeatureDisplayDescriptor
+    let geometry: IMDFAuthoringGeometryDisplayDescriptor
+    let draftProgressText: String
+    let draftStatus: MapEditorDraftStatusDisplayState
+    let categoryRequirement: MapEditorRequirementDisplayState?
+    let referenceRequirement: MapEditorRequirementDisplayState
+    let canAddDraftPoint: Bool
+    let canRemoveDraftPoint: Bool
+    let canFinishDraft: Bool
+    let onToggleCategorySelection: () -> Void
+    let onSatisfyRequiredReferences: () -> Void
+    let onAddDraftPoint: () -> Void
+    let onRemoveLastDraftPoint: () -> Void
+    let onCancelDraft: () -> Void
+    let onFinishDraft: () -> Void
 
     var body: some View {
         IMDFPanel(role: .inspector) {
             VStack(alignment: .leading, spacing: IMDFSpacing.lg) {
-                IMDFInspectorSection(title: viewModel.selectedFeatureDescriptor.title) {
+                IMDFInspectorSection(title: selectedFeature.title) {
                     IMDFInspectorRow(
                         title: "Geometry",
-                        value: viewModel.geometryDescriptor.title,
-                        systemImage: viewModel.geometryDescriptor.systemImage
+                        value: geometry.title,
+                        systemImage: geometry.systemImage
                     )
 
                     IMDFInspectorRow(title: "Draft points", systemImage: "point.3.connected.trianglepath.dotted") {
-                        Text(viewModel.draftProgressText)
+                        Text(draftProgressText)
                     }
 
-                    IMDFInspectorRow(title: "Status", systemImage: viewModel.draftStatus.systemImage) {
+                    IMDFInspectorRow(title: "Status", systemImage: draftStatus.systemImage) {
                         IMDFStatusBadge(
-                            viewModel.draftStatus.title,
-                            systemImage: viewModel.draftStatus.systemImage,
-                            role: viewModel.draftStatus.isReady ? .success : .warning
+                            draftStatus.title,
+                            systemImage: draftStatus.systemImage,
+                            role: draftStatus.isReady ? .success : .warning
                         )
                     }
                 }
 
-                RequirementSection(viewModel: viewModel)
-                DraftControls(viewModel: viewModel)
+                RequirementSection(
+                    categoryRequirement: categoryRequirement,
+                    referenceRequirement: referenceRequirement,
+                    onToggleCategorySelection: onToggleCategorySelection,
+                    onSatisfyRequiredReferences: onSatisfyRequiredReferences
+                )
+                DraftControls(
+                    canAddDraftPoint: canAddDraftPoint,
+                    canRemoveDraftPoint: canRemoveDraftPoint,
+                    canFinishDraft: canFinishDraft,
+                    onAddDraftPoint: onAddDraftPoint,
+                    onRemoveLastDraftPoint: onRemoveLastDraftPoint,
+                    onCancelDraft: onCancelDraft,
+                    onFinishDraft: onFinishDraft
+                )
             }
         }
     }
 }
 
 private struct RequirementSection: View {
-    let viewModel: MapEditorViewModel
+    let categoryRequirement: MapEditorRequirementDisplayState?
+    let referenceRequirement: MapEditorRequirementDisplayState
+    let onToggleCategorySelection: () -> Void
+    let onSatisfyRequiredReferences: () -> Void
 
     var body: some View {
         IMDFInspectorSection(title: "Requirements") {
-            if let categoryRequirement = viewModel.categoryRequirement {
+            if let categoryRequirement {
                 Button {
-                    viewModel.toggleCategorySelection()
+                    onToggleCategorySelection()
                 } label: {
                     requirementRow(
                         state: categoryRequirement
@@ -121,13 +174,13 @@ private struct RequirementSection: View {
                 .buttonStyle(.plain)
             }
 
-            if viewModel.referenceRequirement.value == "None" {
-                requirementRow(state: viewModel.referenceRequirement)
+            if referenceRequirement.value == "None" {
+                requirementRow(state: referenceRequirement)
             } else {
                 Button {
-                    viewModel.satisfyRequiredReferences()
+                    onSatisfyRequiredReferences()
                 } label: {
-                    requirementRow(state: viewModel.referenceRequirement)
+                    requirementRow(state: referenceRequirement)
                 }
                 .buttonStyle(.plain)
             }
@@ -156,33 +209,45 @@ private struct RequirementSection: View {
 }
 
 private struct DraftControls: View {
-    let viewModel: MapEditorViewModel
+    let canAddDraftPoint: Bool
+    let canRemoveDraftPoint: Bool
+    let canFinishDraft: Bool
+    let onAddDraftPoint: () -> Void
+    let onRemoveLastDraftPoint: () -> Void
+    let onCancelDraft: () -> Void
+    let onFinishDraft: () -> Void
 
     var body: some View {
         HStack(spacing: IMDFSpacing.sm) {
             IMDFToolButton(title: "Add point", systemImage: "plus") {
-                viewModel.addDraftPoint()
+                onAddDraftPoint()
             }
-            .disabled(!viewModel.canAddDraftPoint)
+            .disabled(!canAddDraftPoint)
 
             IMDFToolButton(title: "Remove point", systemImage: "minus") {
-                viewModel.removeLastDraftPoint()
+                onRemoveLastDraftPoint()
             }
-            .disabled(!viewModel.canRemoveDraftPoint)
+            .disabled(!canRemoveDraftPoint)
 
             IMDFToolButton(title: "Cancel draft", systemImage: "xmark") {
-                viewModel.cancelDraft()
+                onCancelDraft()
             }
 
             IMDFToolButton(
                 title: "Finish draft",
                 systemImage: "checkmark",
-                isSelected: viewModel.canFinishDraft,
+                isSelected: canFinishDraft,
                 role: .primary
             ) {
-                viewModel.finishDraft()
+                onFinishDraft()
             }
-            .disabled(!viewModel.canFinishDraft)
+            .disabled(!canFinishDraft)
         }
+    }
+}
+
+#Preview("Map Editor") {
+    NavigationStack {
+        MapEditorView(project: IMDFProject(name: "IMDFlex Preview"))
     }
 }

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorView.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorView.swift
@@ -7,7 +7,7 @@ public struct MapEditorView: View {
     let project: IMDFProject
 
     @State private var cameraPosition: MapCameraPosition = .automatic
-    @State private var authoringState = FeatureAuthoringToolState()
+    @State private var viewModel = MapEditorViewModel()
 
     public init(project: IMDFProject) {
         self.project = project
@@ -23,13 +23,13 @@ public struct MapEditorView: View {
                 HStack(alignment: .top, spacing: IMDFSpacing.md) {
                     Spacer(minLength: 0)
 
-                    AuthoringInspector(state: authoringState)
+                    AuthoringInspector(viewModel: viewModel)
                         .frame(width: 300)
                 }
 
                 Spacer(minLength: 0)
 
-                AuthoringFeatureToolbar(state: authoringState)
+                AuthoringFeatureToolbar(viewModel: viewModel)
             }
             .padding(IMDFSpacing.lg)
         }
@@ -50,19 +50,19 @@ public struct MapEditorView: View {
 }
 
 private struct AuthoringFeatureToolbar: View {
-    let state: FeatureAuthoringToolState
+    let viewModel: MapEditorViewModel
 
     var body: some View {
         IMDFPanel(role: .floating) {
             ScrollView(.horizontal) {
                 HStack(spacing: IMDFSpacing.sm) {
-                    ForEach(IMDFAuthoringFeature.allCases) { feature in
+                    ForEach(viewModel.featureTools) { feature in
                         IMDFToolButton(
                             title: feature.title,
                             systemImage: feature.systemImage,
-                            isSelected: state.selectedFeature == feature
+                            isSelected: viewModel.selectedFeature == feature.feature
                         ) {
-                            state.selectFeature(feature)
+                            viewModel.selectFeature(feature.feature)
                         }
                     }
                 }
@@ -73,86 +73,80 @@ private struct AuthoringFeatureToolbar: View {
 }
 
 private struct AuthoringInspector: View {
-    let state: FeatureAuthoringToolState
+    let viewModel: MapEditorViewModel
 
     var body: some View {
         IMDFPanel(role: .inspector) {
             VStack(alignment: .leading, spacing: IMDFSpacing.lg) {
-                IMDFInspectorSection(title: state.selectedFeature.title) {
+                IMDFInspectorSection(title: viewModel.selectedFeatureDescriptor.title) {
                     IMDFInspectorRow(
                         title: "Geometry",
-                        value: state.contract.geometry.title,
-                        systemImage: state.contract.geometry.systemImage
+                        value: viewModel.geometryDescriptor.title,
+                        systemImage: viewModel.geometryDescriptor.systemImage
                     )
 
                     IMDFInspectorRow(title: "Draft points", systemImage: "point.3.connected.trianglepath.dotted") {
-                        Text("\(state.draftedPointCount)/\(state.contract.geometry.minimumPointCount)")
+                        Text(viewModel.draftProgressText)
                     }
 
-                    IMDFInspectorRow(title: "Status", systemImage: state.canFinish ? "checkmark.circle" : "clock") {
+                    IMDFInspectorRow(title: "Status", systemImage: viewModel.draftStatus.systemImage) {
                         IMDFStatusBadge(
-                            state.canFinish ? "Ready" : "Draft",
-                            systemImage: state.canFinish ? "checkmark.circle" : "clock",
-                            role: state.canFinish ? .success : .warning
+                            viewModel.draftStatus.title,
+                            systemImage: viewModel.draftStatus.systemImage,
+                            role: viewModel.draftStatus.isReady ? .success : .warning
                         )
                     }
                 }
 
-                RequirementSection(state: state)
-                DraftControls(state: state)
+                RequirementSection(viewModel: viewModel)
+                DraftControls(viewModel: viewModel)
             }
         }
     }
 }
 
 private struct RequirementSection: View {
-    let state: FeatureAuthoringToolState
+    let viewModel: MapEditorViewModel
 
     var body: some View {
         IMDFInspectorSection(title: "Requirements") {
-            if state.contract.requiresCategory {
+            if let categoryRequirement = viewModel.categoryRequirement {
                 Button {
-                    state.setCategorySelected(!state.hasSelectedCategory)
+                    viewModel.toggleCategorySelection()
                 } label: {
                     requirementRow(
-                        title: "Category",
-                        value: state.hasSelectedCategory ? "Selected" : "Required",
-                        isReady: state.hasSelectedCategory
+                        state: categoryRequirement
                     )
                 }
                 .buttonStyle(.plain)
             }
 
-            if state.contract.requiredReferences.isEmpty {
-                requirementRow(title: "References", value: "None", isReady: true)
+            if viewModel.referenceRequirement.value == "None" {
+                requirementRow(state: viewModel.referenceRequirement)
             } else {
                 Button {
-                    state.satisfyRequiredReferences()
+                    viewModel.satisfyRequiredReferences()
                 } label: {
-                    requirementRow(
-                        title: "References",
-                        value: state.missingReferences.isEmpty ? "Linked" : state.missingReferences.map(\.title).joined(separator: ", "),
-                        isReady: state.missingReferences.isEmpty
-                    )
+                    requirementRow(state: viewModel.referenceRequirement)
                 }
                 .buttonStyle(.plain)
             }
         }
     }
 
-    private func requirementRow(title: String, value: String, isReady: Bool) -> some View {
+    private func requirementRow(state: MapEditorRequirementDisplayState) -> some View {
         HStack(spacing: IMDFSpacing.sm) {
-            Image(systemName: isReady ? "checkmark.circle.fill" : "circle")
+            Image(systemName: state.isReady ? "checkmark.circle.fill" : "circle")
                 .font(.system(size: IMDFIconSize.sm, weight: .semibold))
-                .foregroundStyle(isReady ? IMDFColor.success : .secondary)
+                .foregroundStyle(state.isReady ? IMDFColor.success : .secondary)
 
-            Text(title)
+            Text(state.title)
                 .font(IMDFFont.inspectorLabel)
                 .foregroundStyle(.secondary)
 
             Spacer(minLength: IMDFSpacing.md)
 
-            Text(value)
+            Text(state.value)
                 .font(IMDFFont.inspectorValue)
                 .lineLimit(1)
         }
@@ -162,108 +156,33 @@ private struct RequirementSection: View {
 }
 
 private struct DraftControls: View {
-    let state: FeatureAuthoringToolState
+    let viewModel: MapEditorViewModel
 
     var body: some View {
         HStack(spacing: IMDFSpacing.sm) {
             IMDFToolButton(title: "Add point", systemImage: "plus") {
-                state.addDraftPoint()
+                viewModel.addDraftPoint()
             }
-            .disabled(state.contract.geometry == .form)
+            .disabled(!viewModel.canAddDraftPoint)
 
             IMDFToolButton(title: "Remove point", systemImage: "minus") {
-                state.removeLastDraftPoint()
+                viewModel.removeLastDraftPoint()
             }
-            .disabled(state.draftedPointCount == 0)
+            .disabled(!viewModel.canRemoveDraftPoint)
 
             IMDFToolButton(title: "Cancel draft", systemImage: "xmark") {
-                state.cancel()
+                viewModel.cancelDraft()
             }
 
             IMDFToolButton(
                 title: "Finish draft",
                 systemImage: "checkmark",
-                isSelected: state.canFinish,
+                isSelected: viewModel.canFinishDraft,
                 role: .primary
-            ) {}
-            .disabled(!state.canFinish)
-        }
-    }
-}
-
-private extension IMDFAuthoringFeature {
-    var title: String {
-        switch self {
-        case .address: "Address"
-        case .venue: "Venue"
-        case .building: "Building"
-        case .footprint: "Footprint"
-        case .level: "Level"
-        case .unit: "Unit"
-        case .opening: "Opening"
-        case .amenity: "Amenity"
-        case .anchor: "Anchor"
-        case .occupant: "Occupant"
-        case .detail: "Detail"
-        case .fixture: "Fixture"
-        case .geofence: "Geofence"
-        case .kiosk: "Kiosk"
-        case .relationship: "Relationship"
-        case .section: "Section"
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .address: "mappin.and.ellipse"
-        case .venue: "map"
-        case .building: "building.2"
-        case .footprint: "skew"
-        case .level: "square.stack.3d.up"
-        case .unit: "square.split.2x2"
-        case .opening: "door.left.hand.open"
-        case .amenity: "fork.knife"
-        case .anchor: "pin"
-        case .occupant: "person.crop.square"
-        case .detail: "line.diagonal"
-        case .fixture: "table.furniture"
-        case .geofence: "location.viewfinder"
-        case .kiosk: "display"
-        case .relationship: "point.3.connected.trianglepath.dotted"
-        case .section: "rectangle.3.group"
-        }
-    }
-}
-
-private extension IMDFAuthoringGeometry {
-    var title: String {
-        switch self {
-        case .point: "Point"
-        case .line: "Line"
-        case .polygon: "Polygon"
-        case .form: "Form"
-        }
-    }
-
-    var systemImage: String {
-        switch self {
-        case .point: "smallcircle.filled.circle"
-        case .line: "line.diagonal"
-        case .polygon: "skew"
-        case .form: "list.bullet.rectangle"
-        }
-    }
-}
-
-private extension IMDFAuthoringReference {
-    var title: String {
-        switch self {
-        case .building: "Building"
-        case .level: "Level"
-        case .unit: "Unit"
-        case .anchor: "Anchor"
-        case .levelOrBuilding: "Level or building"
-        case .relationshipEndpoints: "Endpoints"
+            ) {
+                viewModel.finishDraft()
+            }
+            .disabled(!viewModel.canFinishDraft)
         }
     }
 }

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorViewModel.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorViewModel.swift
@@ -1,4 +1,7 @@
+import Domain
+import MapKit
 import Observation
+import SwiftUI
 
 public struct MapEditorRequirementDisplayState: Equatable, Sendable {
     public let title: String
@@ -27,10 +30,23 @@ public struct MapEditorDraftStatusDisplayState: Equatable, Sendable {
 @MainActor
 @Observable
 public final class MapEditorViewModel {
+    public var cameraPosition: MapCameraPosition
+
+    private let project: IMDFProject
     private let authoringState: FeatureAuthoringToolState
 
-    public init(authoringState: FeatureAuthoringToolState = FeatureAuthoringToolState()) {
+    public init(
+        project: IMDFProject,
+        cameraPosition: MapCameraPosition = .automatic,
+        authoringState: FeatureAuthoringToolState = FeatureAuthoringToolState()
+    ) {
+        self.project = project
+        self.cameraPosition = cameraPosition
         self.authoringState = authoringState
+    }
+
+    public var navigationTitle: String {
+        project.name
     }
 
     public var featureTools: [IMDFAuthoringFeatureDisplayDescriptor] {

--- a/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorViewModel.swift
+++ b/IMDFlex/Projects/Presentation/Sources/MapEditor/MapEditorViewModel.swift
@@ -1,0 +1,133 @@
+import Observation
+
+public struct MapEditorRequirementDisplayState: Equatable, Sendable {
+    public let title: String
+    public let value: String
+    public let isReady: Bool
+
+    public init(title: String, value: String, isReady: Bool) {
+        self.title = title
+        self.value = value
+        self.isReady = isReady
+    }
+}
+
+public struct MapEditorDraftStatusDisplayState: Equatable, Sendable {
+    public let title: String
+    public let systemImage: String
+    public let isReady: Bool
+
+    public init(title: String, systemImage: String, isReady: Bool) {
+        self.title = title
+        self.systemImage = systemImage
+        self.isReady = isReady
+    }
+}
+
+@MainActor
+@Observable
+public final class MapEditorViewModel {
+    private let authoringState: FeatureAuthoringToolState
+
+    public init(authoringState: FeatureAuthoringToolState = FeatureAuthoringToolState()) {
+        self.authoringState = authoringState
+    }
+
+    public var featureTools: [IMDFAuthoringFeatureDisplayDescriptor] {
+        MapEditorDisplayDescriptor.features
+    }
+
+    public var selectedFeature: IMDFAuthoringFeature {
+        authoringState.selectedFeature
+    }
+
+    public var selectedFeatureDescriptor: IMDFAuthoringFeatureDisplayDescriptor {
+        MapEditorDisplayDescriptor.featureDescriptor(for: authoringState.selectedFeature)
+    }
+
+    public var geometryDescriptor: IMDFAuthoringGeometryDisplayDescriptor {
+        MapEditorDisplayDescriptor.geometryDescriptor(for: authoringState.contract.geometry)
+    }
+
+    public var draftProgressText: String {
+        "\(authoringState.draftedPointCount)/\(authoringState.contract.geometry.minimumPointCount)"
+    }
+
+    public var draftStatus: MapEditorDraftStatusDisplayState {
+        if authoringState.canFinish {
+            return .init(title: "Ready", systemImage: "checkmark.circle", isReady: true)
+        }
+
+        return .init(title: "Draft", systemImage: "clock", isReady: false)
+    }
+
+    public var categoryRequirement: MapEditorRequirementDisplayState? {
+        guard authoringState.contract.requiresCategory else { return nil }
+
+        return .init(
+            title: "Category",
+            value: authoringState.hasSelectedCategory ? "Selected" : "Required",
+            isReady: authoringState.hasSelectedCategory
+        )
+    }
+
+    public var referenceRequirement: MapEditorRequirementDisplayState {
+        guard !authoringState.contract.requiredReferences.isEmpty else {
+            return .init(title: "References", value: "None", isReady: true)
+        }
+
+        let missingReferences = authoringState.missingReferences
+        let value = missingReferences.isEmpty
+            ? "Linked"
+            : missingReferences
+                .map { MapEditorDisplayDescriptor.referenceDescriptor(for: $0).title }
+                .joined(separator: ", ")
+
+        return .init(
+            title: "References",
+            value: value,
+            isReady: missingReferences.isEmpty
+        )
+    }
+
+    public var canAddDraftPoint: Bool {
+        authoringState.contract.geometry != .form
+    }
+
+    public var canRemoveDraftPoint: Bool {
+        authoringState.draftedPointCount > 0
+    }
+
+    public var canFinishDraft: Bool {
+        authoringState.canFinish
+    }
+
+    public func selectFeature(_ feature: IMDFAuthoringFeature) {
+        authoringState.selectFeature(feature)
+    }
+
+    public func toggleCategorySelection() {
+        authoringState.setCategorySelected(!authoringState.hasSelectedCategory)
+    }
+
+    public func satisfyRequiredReferences() {
+        authoringState.satisfyRequiredReferences()
+    }
+
+    public func addDraftPoint() {
+        authoringState.addDraftPoint()
+    }
+
+    public func removeLastDraftPoint() {
+        authoringState.removeLastDraftPoint()
+    }
+
+    public func cancelDraft() {
+        authoringState.cancel()
+    }
+
+    @discardableResult
+    public func finishDraft() -> IMDFDrawingDraftResult? {
+        authoringState.finishDrawingDraft()
+    }
+}

--- a/IMDFlex/Projects/Presentation/Tests/MapEditorViewModelTests.swift
+++ b/IMDFlex/Projects/Presentation/Tests/MapEditorViewModelTests.swift
@@ -1,8 +1,20 @@
 import XCTest
 @testable import Presentation
+import Domain
 
 @MainActor
 final class MapEditorViewModelTests: XCTestCase {
+    func test_whenViewModelIsCreated_thenItExposesProjectNavigationTitle() {
+        // Given
+        let sut = makeSUT(project: .fixture(name: "Preview Mall"))
+
+        // When
+        let title = sut.navigationTitle
+
+        // Then
+        XCTAssertEqual(title, "Preview Mall")
+    }
+
     func test_whenViewModelIsCreated_thenItExposesDefaultUnitDisplayState() {
         // Given
         let sut = makeSUT()
@@ -120,7 +132,13 @@ final class MapEditorViewModelTests: XCTestCase {
         XCTAssertFalse(sut.canFinishDraft)
     }
 
-    private func makeSUT() -> MapEditorViewModel {
-        MapEditorViewModel()
+    private func makeSUT(project: IMDFProject = .fixture()) -> MapEditorViewModel {
+        MapEditorViewModel(project: project)
+    }
+}
+
+private extension IMDFProject {
+    static func fixture(name: String = "Test Project") -> Self {
+        .init(name: name)
     }
 }

--- a/IMDFlex/Projects/Presentation/Tests/MapEditorViewModelTests.swift
+++ b/IMDFlex/Projects/Presentation/Tests/MapEditorViewModelTests.swift
@@ -1,0 +1,126 @@
+import XCTest
+@testable import Presentation
+
+@MainActor
+final class MapEditorViewModelTests: XCTestCase {
+    func test_whenViewModelIsCreated_thenItExposesDefaultUnitDisplayState() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        let selectedFeature = sut.selectedFeatureDescriptor
+        let geometry = sut.geometryDescriptor
+
+        // Then
+        XCTAssertEqual(selectedFeature.feature, .unit)
+        XCTAssertEqual(selectedFeature.title, "Unit")
+        XCTAssertEqual(selectedFeature.systemImage, "square.split.2x2")
+        XCTAssertEqual(geometry.geometry, .polygon)
+        XCTAssertEqual(geometry.title, "Polygon")
+    }
+
+    func test_whenFeatureIsSelected_thenViewModelUpdatesDisplayStateAndDraftProgress() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.selectFeature(.opening)
+
+        // Then
+        XCTAssertEqual(sut.selectedFeature, .opening)
+        XCTAssertEqual(sut.selectedFeatureDescriptor.title, "Opening")
+        XCTAssertEqual(sut.geometryDescriptor.geometry, .line)
+        XCTAssertEqual(sut.draftProgressText, "0/2")
+    }
+
+    func test_whenCategorySelectionIsToggled_thenCategoryRequirementBecomesReady() throws {
+        // Given
+        let sut = makeSUT()
+        sut.selectFeature(.amenity)
+
+        // When
+        sut.toggleCategorySelection()
+
+        // Then
+        let categoryRequirement = try XCTUnwrap(sut.categoryRequirement)
+        XCTAssertEqual(categoryRequirement.title, "Category")
+        XCTAssertEqual(categoryRequirement.value, "Selected")
+        XCTAssertTrue(categoryRequirement.isReady)
+    }
+
+    func test_whenReferencesAreRequiredAndSatisfied_thenReferenceRequirementBecomesReady() {
+        // Given
+        let sut = makeSUT()
+        sut.selectFeature(.relationship)
+
+        // When
+        sut.satisfyRequiredReferences()
+
+        // Then
+        XCTAssertEqual(sut.referenceRequirement.title, "References")
+        XCTAssertEqual(sut.referenceRequirement.value, "Linked")
+        XCTAssertTrue(sut.referenceRequirement.isReady)
+    }
+
+    func test_whenDraftPointIsAdded_thenDraftProgressAndRemoveAvailabilityUpdate() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.addDraftPoint()
+
+        // Then
+        XCTAssertEqual(sut.draftProgressText, "1/3")
+        XCTAssertTrue(sut.canRemoveDraftPoint)
+    }
+
+    func test_whenFormFeatureIsSelected_thenDraftPointCannotBeAdded() {
+        // Given
+        let sut = makeSUT()
+
+        // When
+        sut.selectFeature(.building)
+
+        // Then
+        XCTAssertFalse(sut.canAddDraftPoint)
+        XCTAssertEqual(sut.draftProgressText, "0/0")
+    }
+
+    func test_whenDraftCanFinish_thenFinishDraftReturnsResult() throws {
+        // Given
+        let sut = makeSUT()
+        sut.toggleCategorySelection()
+        sut.satisfyRequiredReferences()
+        sut.addDraftPoint()
+        sut.addDraftPoint()
+        sut.addDraftPoint()
+
+        // When
+        let result = try XCTUnwrap(sut.finishDraft())
+
+        // Then
+        XCTAssertEqual(result.geometry, .polygon)
+        XCTAssertEqual(result.coordinates.count, 3)
+    }
+
+    func test_whenDraftIsCancelled_thenDisplayStateResetsForSelectedFeature() {
+        // Given
+        let sut = makeSUT()
+        sut.toggleCategorySelection()
+        sut.satisfyRequiredReferences()
+        sut.addDraftPoint()
+
+        // When
+        sut.cancelDraft()
+
+        // Then
+        XCTAssertEqual(sut.selectedFeature, .unit)
+        XCTAssertEqual(sut.draftProgressText, "0/3")
+        XCTAssertFalse(sut.canRemoveDraftPoint)
+        XCTAssertFalse(sut.canFinishDraft)
+    }
+
+    private func makeSUT() -> MapEditorViewModel {
+        MapEditorViewModel()
+    }
+}

--- a/docs/editor-shell-foundation.md
+++ b/docs/editor-shell-foundation.md
@@ -22,6 +22,7 @@ This keeps the workflow map-first while letting the UI progressively disclose on
 Map editor Presentation code should follow a strict MVVM boundary:
 
 - SwiftUI views render display-ready state and call ViewModel intents.
+- Child views receive the smallest needed values and intent closures, not the entire parent ViewModel, unless they represent a separate screen-level MVVM boundary.
 - ViewModels orchestrate user intents and combine focused Presentation state models.
 - Display descriptors own feature, geometry, reference, label, icon, and status mapping.
 - Focused state models, such as drawing drafts, should remain small and should not know about SwiftUI view layout.

--- a/docs/editor-shell-foundation.md
+++ b/docs/editor-shell-foundation.md
@@ -17,6 +17,18 @@ This keeps the workflow map-first while letting the UI progressively disclose on
 
 ## Component Boundary
 
+### Presentation MVVM
+
+Map editor Presentation code should follow a strict MVVM boundary:
+
+- SwiftUI views render display-ready state and call ViewModel intents.
+- ViewModels orchestrate user intents and combine focused Presentation state models.
+- Display descriptors own feature, geometry, reference, label, icon, and status mapping.
+- Focused state models, such as drawing drafts, should remain small and should not know about SwiftUI view layout.
+- Domain feature creation, persistence, export, and validation should stay behind future use cases, services, or coordinators.
+
+Do not add editor workflow orchestration directly to `MapEditorView` or its private child views. If a view needs to decide what a feature means, which requirement is ready, or which action should mutate state, move that decision into a ViewModel or descriptor first.
+
 ### DesignSystem
 
 DesignSystem should provide small, reusable primitives that do not know about IMDF feature semantics.

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -104,6 +104,8 @@ Test repository behavior, serializers, exporters, ZIP structure, GeoJSON shape, 
 
 Test observable state models, coordinators, editor state machines, drawing tools, and async user flows. Public APIs should be awaitable whenever possible. Avoid hidden `Task {}` timing that forces sleeps or flaky expectations.
 
+For MVVM surfaces, test ViewModel display state and intents directly. SwiftUI views should be thin enough that they mainly need build verification until snapshot/UI testing is explicitly introduced.
+
 ### DesignSystem And App
 
 Prefer build verification unless there is meaningful behavior to test. Snapshot testing for SwiftUI views can be considered later with explicit dependency approval.


### PR DESCRIPTION
## Summary

Refactors the map editor Presentation layer back toward Clean Architecture and MVVM. SwiftUI views now render display-ready state from a `MapEditorViewModel` and call ViewModel intents instead of directly orchestrating authoring state.

## Type

- [ ] `feat:` user-facing feature
- [ ] `fix:` bug fix
- [ ] `fix:` hotfix
- [x] `refactor:` internal restructuring
- [ ] `chore:` maintenance/tooling
- [ ] `docs:` documentation
- [ ] `test:` tests only

## Changes

- Added `MapEditorViewModel` as the map editor Presentation orchestration boundary.
- Moved feature, geometry, and reference display mapping into display descriptors.
- Updated `MapEditorView` so it calls ViewModel intents instead of mutating `FeatureAuthoringToolState` directly.
- Added ViewModel tests for feature selection, category/reference readiness, draft progress, finish, and cancel behavior.
- Documented the Presentation MVVM boundary in `AGENTS.md`, `docs/editor-shell-foundation.md`, and `docs/testing-strategy.md`.

## IMDF Impact

- None.
- This is a Presentation refactor only.
- No GeoJSON, export, preflight, or Apple IMDF Validator behavior changes.

## Architecture Notes

- SwiftUI views should stay thin: render display-ready state and call ViewModel intents.
- ViewModels own cross-state orchestration.
- Display descriptors own feature/geometry/reference labels and icons.
- `DrawingDraftState` and `FeatureAuthoringToolState` remain focused lower-level Presentation state models.
- Future Presentation work should preserve this boundary before adding MapKit gestures, category pickers, inspectors, or Domain mutation.

## Verification

- [ ] `Domain`: Not run directly; no Domain source changes.
- [ ] `Data`: Not run directly; no Data source changes.
- [x] `Presentation`: `mise exec -- tuist test Presentation` passed, 30 tests.
- [ ] `DesignSystem`: Not run directly; no DesignSystem source changes.
- [x] `App`: `mise exec -- tuist build IMDFlex` passed.
- [ ] `mise exec -- tuist generate --no-binary-cache --no-open`: Not run; no Tuist manifest changes.
- [ ] Apple IMDF Validator / preflight: Not applicable; no export/preflight behavior changes.

## Screenshots Or Recording

Not applicable; this PR preserves the current editor shell behavior while moving orchestration behind a ViewModel.

## Related Issues

Closes #37

## Checklist

- [x] Issue exists before implementation work.
- [x] Branch name follows `<type>/<issue-number>-<short-kebab-summary>`.
- [x] PR title uses `feat:`, `fix:`, `refactor:`, `chore:`, `docs:`, or `test:`.
- [x] Changes access other modules through public interfaces/protocols.
- [x] IMDF schema assumptions are documented or linked.
- [x] User-facing behavior has been tested or explained.
